### PR TITLE
Ignore generated __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+gpodder
+jsonconfig.py
+main.py
+podcastparser.py
+qml/common
+__pycache__


### PR DESCRIPTION
Adding a .gitignore file containing generated dirs and symlinks, so it's easier to track changes when running gPodder directly from a git clone
