### PR TITLE
MPRIS and Headset Media Keys

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -70,6 +70,7 @@ PodcastsPage {
     }
     
     MprisPlayer {}
+    MediaKeys {}
 
     GPodderPodcastListModel { id: podcastListModel }
     GPodderPodcastListModelConnections {}

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -68,6 +68,8 @@ PodcastsPage {
         id: player
         onPlayerCreated: pgst.createPlayerPage();
     }
+    
+    MprisPlayer {}
 
     GPodderPodcastListModel { id: podcastListModel }
     GPodderPodcastListModelConnections {}

--- a/qml/MediaKeys.qml
+++ b/qml/MediaKeys.qml
@@ -1,0 +1,35 @@
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Media 1.0
+
+
+Item {
+
+    MediaKey {
+        enabled: true
+        key: Qt.Key_MediaTogglePlayPause
+        onReleased: player.togglePause()
+    }
+    MediaKey {
+        enabled: true
+        key: Qt.Key_MediaPlay
+        onReleased: player.play()
+    }
+    MediaKey {
+        enabled: true
+        key: Qt.Key_MediaPause
+        onReleased: player.pause()
+    }
+    MediaKey {
+        enabled: true
+        key: Qt.Key_ToggleCallHangup
+        onReleased: player.togglePause()
+    }
+    MediaKey {
+        enabled: true
+        key: Qt.Key_MediaStop
+        onReleased: player.stop()
+    }
+
+}

--- a/qml/MprisPlayer.qml
+++ b/qml/MprisPlayer.qml
@@ -1,0 +1,67 @@
+
+import QtQuick 2.0
+import QtMultimedia 5.0
+import org.nemomobile.mpris 1.0
+
+MprisPlayer {
+
+    id: mprisPlayer
+
+    serviceName: "gpodder"
+
+    property string title: streamTitle
+
+    onTitleChanged: {
+        if (title != "") {
+            var metadata = mprisPlayer.metadata
+            metadata[Mpris.metadataToString(Mpris.Title)] = title
+            mprisPlayer.metadata = metadata
+        }
+    }
+
+    // Mpris2 Root Interface
+    identity: "Mpris gpodder-sailfish"
+
+    // Mpris2 Player Interface
+    canControl: true
+
+    canGoNext: player.playbackState != MediaPlayer.StoppedState
+    canGoPrevious: player.playbackState != MediaPlayer.StoppedState
+    canPause: player.playbackState != MediaPlayer.StoppedState
+    canPlay: player.playbackState != MediaPlayer.StoppedState
+    canSeek: false
+
+    loopStatus: Mpris.None
+    shuffle: false
+    volume: 1
+
+    playbackStatus: {
+        if (player.playbackState == MediaPlayer.PlayingState) return Mpris.Playing
+        else if (player.playbackState == MediaPlayer.PausedState) return Mpris.Paused
+        else return Mpris.Stopped
+    }
+    onPlaybackStatusChanged: {
+        title = player.episode_title
+    }
+
+    onPauseRequested: {
+        player.pause()
+    }
+    onPlayRequested: {
+        player.play()
+    }
+    onPlayPauseRequested: {
+        player.togglePause()
+    }
+    onStopRequested: {
+        player.stop()
+    }
+    
+    onNextRequested: {
+        player.seekAndSync(player.position + 1000 * 10)
+    }
+    onPreviousRequested: {
+        player.seekAndSync(player.position - 1000 * 10)
+    }
+    
+}

--- a/rpm/harbour-org.gpodder.sailfish.spec
+++ b/rpm/harbour-org.gpodder.sailfish.spec
@@ -13,6 +13,7 @@ Group: System/GUI/Other
 Requires: pyotherside-qml-plugin-python3-qt5 >= 1.3.0
 Requires: sailfishsilica-qt5
 Requires: libsailfishapp-launcher
+Requires: mpris-qt5
 
 %description
 gPodder downloads and manages free audio and video content for you.


### PR DESCRIPTION
I added MPRIS support (https://github.com/gpodder/gpodder-sailfish/issues/43) and remote control using the headset button (https://github.com/gpodder/gpodder-sailfish/issues/6).

MPRIS uses https://github.com/nemomobile/qtmpris as also mentioned in the issue. I am not sure whether this meets the Harbour terms. But one could include it for an OpenRepos build.