### PR TITLE
add build and development instructions to README

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,0 @@
-gPodder 4 for Sailfish OS
-=========================
-
-This repository contains the platform-specific customizations and packaging for
-running gPodder 4 on Sailfish OS. Python 3.3.3 and PyOtherSide is already included
-in the device repositories starting with Sailfish OS 1.0.3.8.

--- a/README.md
+++ b/README.md
@@ -4,24 +4,24 @@ This repository contains the platform-specific customizations and packaging for
 running gPodder 4 on Sailfish OS. Python 3.3.3 and PyOtherSide is already included
 in the device repositories starting with Sailfish OS 1.0.3.8.
 
-## getting started with development
+## Getting Started with Development
 
-### development on device/ in emulator
+### Development on Device/ in Emulator
 
 There is the possibility to directly clone the repository to the device/ emulator and work there:
 
-1. connect via SSH to your SailfishOS device
+1. Connect via SSH to your SailfishOS device
     e.g. connect to emulator: `ssh -p 2223 -i ~/SailfishOS/vmshare/ssh/private_keys/SailfishOS_Emulator/nemo nemo@localhost`
-1. install the needed packages: `pkcon install git pyotherside-qml-plugin-python3-qt5`
-1. clone this repo: `git clone --recursive https://github.com/gpodder/gpodder-sailfish.git`
-1. set up development symlinks:
+1. Install the needed packages: `pkcon install git pyotherside-qml-plugin-python3-qt5`
+1. Clone this repo: `git clone --recursive https://github.com/gpodder/gpodder-sailfish.git`
+1. Set up development symlinks:
     ```
     cd gpodder-sailfish
     bash dev_symlinks.sh
     ```
-1. launch main qml file: `/usr/lib/qt5/bin/qmlscene qml/harbour-org.gpodder.sailfish.qml`
+1. Launch main qml file: `/usr/lib/qt5/bin/qmlscene qml/harbour-org.gpodder.sailfish.qml`
 
-### building RPM package
+### Building RPM Package
 
 The RPM package can be build in the *SailfishOS Build Engine* VM
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ There is the possibility to directly clone the repository to the device/ emulato
 1. set up development symlinks:
     ```
     cd gpodder-sailfish
-    sh dev_symlinks.sh
+    bash dev_symlinks.sh
     ```
 1. launch main qml file: `/usr/lib/qt5/bin/qmlscene qml/harbour-org.gpodder.sailfish.qml`
+
+### building RPM package
+
+The RPM package can be build in the *SailfishOS Build Engine* VM
+
+1. Start the *Sailfish OS Build Engine* VM
+1. Connect to it via SSH: `ssh -p 2222 -i ~/SailfishOS/vmshare/ssh/private_keys/engine/mersdk mersdk@localhost`
+1. Move to your source code directory. You can usually access your home directory via the `~/share/` directory from inside the build engine
+1. In case you created development symlinks (see above): remove them using `bash dev_symlinks --unlink`
+1. Build the package using `mb2 -t SailfishOS-armv7hl build` (change target architecture to your needs)
+1. The built package can be found in the `RPMS` directory.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# gPodder 4 for Sailfish OS
+
+This repository contains the platform-specific customizations and packaging for
+running gPodder 4 on Sailfish OS. Python 3.3.3 and PyOtherSide is already included
+in the device repositories starting with Sailfish OS 1.0.3.8.
+
+## getting started with development
+
+### development on device/ in emulator
+
+There is the possibility to directly clone the repository to the device/ emulator and work there:
+
+1. connect via SSH to your SailfishOS device
+    e.g. connect to emulator: `ssh -p 2223 -i ~/SailfishOS/vmshare/ssh/private_keys/SailfishOS_Emulator/nemo nemo@localhost`
+1. install the needed packages: `pkcon install git pyotherside-qml-plugin-python3-qt5`
+1. clone this repo: `git clone --recursive https://github.com/gpodder/gpodder-sailfish.git`
+1. set up development symlinks:
+    ```
+    cd gpodder-sailfish
+    sh dev_symlinks.sh
+    ```
+1. launch main qml file: `/usr/lib/qt5/bin/qmlscene qml/harbour-org.gpodder.sailfish.qml`

--- a/dev_symlinks.sh
+++ b/dev_symlinks.sh
@@ -58,7 +58,7 @@ case "$1" in
 	'')
 		create_symlinks;;
 	*)
-		echo "invalid argument"
+		echo "invalid argument. Try \`$0 --help\` for more information."
 		exit -1
 esac
 

--- a/dev_symlinks.sh
+++ b/dev_symlinks.sh
@@ -2,8 +2,12 @@
 # Create symlinks into Git submodules, so the project can
 # be started with qmlscene directly from a source checkout
 
-# array of symlinks in form "$TARGET","$LINK_NAME"
-SYMLINKS=("gpodder-core/src/gpodder","gpodder" "podcastparser/podcastparser.py","podcastparser.py" "gpodder-ui-qml/main.py","main.py" "../gpodder-ui-qml/common","qml/common" "minidb/minidb.py","minidb.py")
+# array of symlinks in form "$TARGET","$LINK_NAME", take care of the spaces between the entries
+SYMLINKS=("gpodder-core/src/gpodder","gpodder" \
+	"podcastparser/podcastparser.py","podcastparser.py" \
+	"gpodder-ui-qml/main.py","main.py" \
+	"../gpodder-ui-qml/common","qml/common" \
+	"minidb/minidb.py","minidb.py")
 
 help() {
 	echo "Manage symlinks into Git submodules, so the project can

--- a/dev_symlinks.sh
+++ b/dev_symlinks.sh
@@ -18,11 +18,6 @@ default behaviour: create symlinks into Git submodules
 }
 
 create_symlinks() {
-#	ln -sf gpodder-core/src/gpodder .
-#	ln -sf podcastparser/podcastparser.py .
-#	ln -sf gpodder-ui-qml/main.py .
-#	ln -sf ../gpodder-ui-qml/common qml
-#	ln -sf minidb/minidb.py .
 
 	# emulate iteration over tuples by splitting at ','
 	OLDIFS=$IFS

--- a/dev_symlinks.sh
+++ b/dev_symlinks.sh
@@ -1,9 +1,70 @@
-#!/bin/sh
+#!/bin/bash
 # Create symlinks into Git submodules, so the project can
 # be started with qmlscene directly from a source checkout
 
-ln -sf gpodder-core/src/gpodder .
-ln -sf podcastparser/podcastparser.py .
-ln -sf gpodder-ui-qml/main.py .
-ln -sf ../gpodder-ui-qml/common qml
-ln -sf minidb/minidb.py .
+# array of symlinks in form "$TARGET","$LINK_NAME"
+SYMLINKS=("gpodder-core/src/gpodder","gpodder" "podcastparser/podcastparser.py","podcastparser.py" "gpodder-ui-qml/main.py","main.py" "../gpodder-ui-qml/common","qml/common" "minidb/minidb.py","minidb.py")
+
+help() {
+	echo "Manage symlinks into Git submodules, so the project can
+be started with qmlscene directly from a source checkout
+
+Usage:
+$0 [--unlink | --help]
+
+default behaviour: create symlinks into Git submodules
+--unlink: remove symlinks again
+--help: display this help"
+}
+
+create_symlinks() {
+#	ln -sf gpodder-core/src/gpodder .
+#	ln -sf podcastparser/podcastparser.py .
+#	ln -sf gpodder-ui-qml/main.py .
+#	ln -sf ../gpodder-ui-qml/common qml
+#	ln -sf minidb/minidb.py .
+
+	# emulate iteration over tuples by splitting at ','
+	OLDIFS=$IFS
+	for i in ${SYMLINKS[*]}; do
+		IFS=',' read -r TARGET LINK_NAME <<< "${i}"
+		ln -sf "$TARGET" "$LINK_NAME"
+	done
+	IFS=$OLDIFS
+}
+
+delete_symlinks() {
+
+	# check first whether all targets are symlinks before deleting them
+	# emulate iteration over tuples by splitting at ','
+	OLDIFS=$IFS
+	for i in ${SYMLINKS[*]}; do
+		IFS=',' read -r TARGET LINK_NAME <<< "${i}"
+		if [ ! -L "$LINK_NAME" ]; then
+			echo "Error: $LINK_NAME is no symlink or doesn't exist. Aborting." >&2
+			exit -2
+		fi
+	done
+
+	# now actually delete them
+	for i in ${SYMLINKS[*]}; do
+		IFS=',' read -r TARGET LINK_NAME <<< "${i}"
+		rm "$LINK_NAME"
+	done
+	IFS=$OLDIFS
+}
+
+case "$1" in
+	"--help"|"-h")
+		help
+		exit 1;;
+	"--unlink")
+		delete_symlinks;;
+	'')
+		create_symlinks;;
+	*)
+		echo "invalid argument"
+		exit -1
+esac
+
+exit 0


### PR DESCRIPTION
So far I mostly added the build instructions from #46 to the README, so possible contributors could find them easier.
I also modified the dev_symlinks.sh script to conveniently remove the created symlinks again.

@thp: I'd be interested in how your development and build workflow used to be and which tools/ editors (QtCreator?) you used. I haven't really worked with the code so far, but this should be a good basis for getting started.