### PR TITLE
Default filter set to 'Downloaded'. 

### DIFF
--- a/qml/AllEpisodesPage.qml
+++ b/qml/AllEpisodesPage.qml
@@ -25,13 +25,13 @@ import 'common'
 import 'common/util.js' as Util
 
 Page {
-    id: freshEpisodes
+    id: filteredEpisodes
     allowedOrientations: Orientation.All
 
     onStatusChanged: pgst.handlePageStatusChange(status)
 
     Component.onCompleted: {
-        episodeListModel.setQuery(episodeListModel.queries.Fresh);
+        episodeListModel.setQuery(episodeListModel.queries.Downloaded);
         episodeListModel.reload();
     }
 
@@ -42,14 +42,14 @@ Page {
     }
 
     SilicaListView {
-        id: freshEpisodesList
+        id: filteredEpisodesList
         anchors.fill: parent
 
         PullDownMenu {
             EpisodeListFilterItem { id: filterItem; model: episodeListModel }
         }
 
-        VerticalScrollDecorator { flickable: freshEpisodesList }
+        VerticalScrollDecorator { flickable: filteredEpisodesList }
 
         header: PageHeader {
             title: qsTr("Episodes: ") + filterItem.currentFilter
@@ -67,7 +67,7 @@ Page {
         delegate: EpisodeItem {}
 
         ViewPlaceholder {
-            enabled: freshEpisodesList.count == 0 && episodeListModel.ready
+            enabled: filteredEpisodesList.count == 0 && episodeListModel.ready
             text: qsTr("No episodes found")
         }
     }

--- a/qml/EpisodeItem.qml
+++ b/qml/EpisodeItem.qml
@@ -108,7 +108,7 @@ ListItem {
                 onClicked: {
                     episodeItem.hideMenu();
                     var ctx = { py: py, id: id };
-                    episodeItem.remorseAction('Deleting', function () {
+                    episodeItem.remorseAction(qsTr("Deleting"), function () {
                         ctx.py.call('main.delete_episode', [ctx.id]);
                     });
                 }

--- a/translations/harbour-org.gpodder.sailfish-bg.ts
+++ b/translations/harbour-org.gpodder.sailfish-bg.ts
@@ -117,6 +117,11 @@
         <translation>Изтриване</translation>
     </message>
     <message>
+        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <source>Deleting</source>
+        <translation>Ще се изтрие</translation>
+    </message>
+    <message>
         <location filename="../qml/EpisodeItem.qml" line="119"/>
         <source>Toggle New</source>
         <translation>Като нов</translation>

--- a/translations/harbour-org.gpodder.sailfish-bg.ts
+++ b/translations/harbour-org.gpodder.sailfish-bg.ts
@@ -16,7 +16,7 @@
     <message>
         <location filename="../qml/AboutPage.qml" line="77"/>
         <source>License: ISC / GPLv3 or later</source>
-        <translation>Лиценз: ISC / GPLv3 или по-късен </translation>
+        <translation>Лиценз: ISC / GPLv3 или по-късен</translation>
     </message>
     <message>
         <location filename="../qml/AboutPage.qml" line="78"/>
@@ -217,7 +217,7 @@
     <message>
         <location filename="../qml/PlayerPage.qml" line="67"/>
         <source>Player</source>
-        <translation>Прослушвач</translation>
+        <translation>Прослушване</translation>
     </message>
     <message>
         <location filename="../qml/PlayerPage.qml" line="100"/>

--- a/translations/harbour-org.gpodder.sailfish-de.ts
+++ b/translations/harbour-org.gpodder.sailfish-de.ts
@@ -117,6 +117,11 @@
         <translation>Löschen</translation>
     </message>
     <message>
+        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <source>Deleting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../qml/EpisodeItem.qml" line="119"/>
         <source>Toggle New</source>
         <translation>Neu umschalten</translation>

--- a/translations/harbour-org.gpodder.sailfish-es.ts
+++ b/translations/harbour-org.gpodder.sailfish-es.ts
@@ -117,6 +117,11 @@
         <translation>Borrar</translation>
     </message>
     <message>
+        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <source>Deleting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../qml/EpisodeItem.qml" line="119"/>
         <source>Toggle New</source>
         <translation>Nuevo</translation>

--- a/translations/harbour-org.gpodder.sailfish.ts
+++ b/translations/harbour-org.gpodder.sailfish.ts
@@ -117,6 +117,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <source>Deleting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../qml/EpisodeItem.qml" line="119"/>
         <source>Toggle New</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
Also, refactored code to make naming general.

It might be just me, bit I find the default filter Fresh to be quite useless, so I switched it to Downloaded - now I have quick overview of all podcasts that are available to me for listening. 

In the long run the default filter should be selectable and persisted, but this is for the future. 
I am also considering the feature of adding the filter view as a screen to the left of the gPodder homescreen. 
Any thoughts?
