### PR TITLE
Refresh cover action available right after gPodder initial start

### DIFF
--- a/qml/CoverContainer.qml
+++ b/qml/CoverContainer.qml
@@ -73,4 +73,17 @@ CoverBackground {
             }
         }
     }
+
+    CoverActionList {
+        enabled: player.episode == 0 && !player.isPlaying
+
+        CoverAction {
+            iconSource: 'image://theme/icon-cover-sync'
+            onTriggered: {
+                if (!py.refreshing) {
+                    py.call('main.check_for_episodes');
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Previously, the refresh cover action was only available after an episode was played. It makse sense that it is possible to refresh if no episode has been played after initial start of the app.