### PR TITLE
Fix for issue #86

### DIFF
--- a/qml/EpisodeDetail.qml
+++ b/qml/EpisodeDetail.qml
@@ -189,6 +189,7 @@ Page {
             }
 
             Label {
+                textFormat: Text.StyledText
                 text: detailPage.description
                 linkColor: Theme.highlightColor
                 anchors {


### PR DESCRIPTION
Makes HTML formatted descriptions show nicely. Text.RichText can be used too, but some descriptions contain own styles that garble text displayed by the app. Test case - Netxpolitik podcast.