### PR TITLE
Visual improvements to EpisodeItem

### DIFF
--- a/qml/EpisodeItem.qml
+++ b/qml/EpisodeItem.qml
@@ -207,31 +207,6 @@ ListItem {
         property string title_char: podcast_title[0]
     }
 
-    Label {
-        id: downloadStatusIcon
-
-        anchors {
-            right: parent.right
-            verticalCenter: parent.verticalCenter
-            rightMargin: text ? Theme.paddingMedium : 0
-        }
-
-        font.pixelSize: Theme.fontSizeLarge
-        font.bold: true
-
-        opacity: titleItem.opacity
-
-        color: titleItem.color
-
-        text: {
-            switch (downloadState) {
-                case Constants.state.normal: return '';
-                case Constants.state.downloaded: return '';
-                case Constants.state.deleted: return '';
-            }
-        }
-    }
-
     Rectangle {
         id: downloadStatusIndicator
         anchors {

--- a/qml/EpisodeItem.qml
+++ b/qml/EpisodeItem.qml
@@ -42,7 +42,7 @@ ListItem {
             left: parent.left
         }
 
-        height: parent.height * 0.2
+        height: parent.height * 0.1
         width: parent.width * progress
 
         color: Theme.highlightColor
@@ -55,7 +55,7 @@ ListItem {
             left: parent.left
         }
 
-        height: parent.height * 0.2
+        height: parent.height * 0.1
         width: parent.width * playbackProgress
 
         color: isPlaying ? Theme.highlightColor : Theme.secondaryHighlightColor
@@ -147,7 +147,7 @@ ListItem {
     Column {
         anchors {
             left: artArea.right
-            right: downloadStatusIcon.left
+            right: downloadStatusIndicator.left
             verticalCenter: parent.verticalCenter
             margins: Theme.paddingMedium
         }
@@ -183,7 +183,7 @@ ListItem {
 
         Label {
             id: subtitleItem
-            text: total_time > 0 ? (subtitle != '' ? Util.formatDuration(total_time) + ' | ' + subtitle : Util.formatDuration(total_time)) : subtitle
+            text: (mime[0] === 'video' ? '🎬' : '') + (total_time > 0 ? (subtitle != '' ? Util.formatDuration(total_time) + ' | ' + subtitle : Util.formatDuration(total_time)) : subtitle)
             anchors {
                 left: titleItem.left
                 right: titleItem.right
@@ -199,15 +199,16 @@ ListItem {
         id: artArea
         anchors {
             left: parent.left
+            verticalCenter: parent.verticalCenter
         }
-        height: titleItem.height + subtitleItem.height
-        width: titleItem.height + subtitleItem.height
+        height: parent.height * 0.8
+        width: parent.height * 0.8
         property string episode_art: ''
         property string title_char: podcast_title[0]
     }
 
     Label {
-        id: videoIcon
+        id: downloadStatusIcon
 
         anchors {
             right: parent.right
@@ -222,31 +223,33 @@ ListItem {
 
         color: titleItem.color
 
-        text: mime[0] == 'video' ? '🎬' : '';
-    }
-
-    Label {
-        id: downloadStatusIcon
-
-        anchors {
-            right: mime[0] == 'video' ? videoIcon.left : parent.right
-            verticalCenter: parent.verticalCenter
-            rightMargin: text ? Theme.paddingMedium : 0
-        }
-
-        font.pixelSize: Theme.fontSizeLarge
-        font.bold: true
-
-        opacity: titleItem.opacity
-
-        color: titleItem.color
-
         text: {
             switch (downloadState) {
                 case Constants.state.normal: return '';
-                case Constants.state.downloaded: return '♫';
+                case Constants.state.downloaded: return '';
                 case Constants.state.deleted: return '';
             }
         }
+    }
+
+    Rectangle {
+        id: downloadStatusIndicator
+        anchors {
+            right: parent.right
+            verticalCenter: parent.verticalCenter
+        }
+
+        height: parent.height * 0.8
+        width: parent.height * 0.1
+
+        visible: {
+            switch (downloadState) {
+                case Constants.state.normal: return false;
+                case Constants.state.downloaded: return true;
+                case Constants.state.deleted: return false;
+            }
+        }
+        color: Theme.highlightColor
+        opacity: .8
     }
 }


### PR DESCRIPTION
- ArtArea made 0.8 high and vertically centred to make space for progress bars above and below (the download bar was completely covered by the ArtArea until now)
- Progress bars made thinner and more elegant (0.1 of parent height, was 0.2)
- The video identifier made more subtle and moved to the beginning of the subtitle
- Downloaded icon exchanged for a vertical bar on the right. (The musical note icon did not make any sense as a downloaded signifier, even less so for videos).

I hope you like it! :)

Before:
![before](https://user-images.githubusercontent.com/24361624/81486271-d6171800-9253-11ea-9865-416d9c455f80.png)

After:
![after](https://user-images.githubusercontent.com/24361624/81486256-cb5c8300-9253-11ea-8de7-493940e85d98.png)
