### PR TITLE
UI improvments for episodelist

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "gpodder-core"]
 	path = gpodder-core
 	url = git://github.com/gpodder/gpodder-core.git
-[submodule "gpodder-ui-qml"]
-	path = gpodder-ui-qml
-	url = git://github.com/gpodder/gpodder-ui-qml.git
 [submodule "podcastparser"]
 	path = podcastparser
 	url = git://github.com/gpodder/podcastparser.git

--- a/gpodder-ui-qml/common/GPodderAutoFire.qml
+++ b/gpodder-ui-qml/common/GPodderAutoFire.qml
@@ -1,0 +1,45 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2015, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+import QtQuick 2.0
+
+Timer {
+    property int triggerCount: 0
+    property int initialInterval: 1500
+    property int autoFireInterval: 200
+
+    signal fired()
+
+    interval: triggerCount > 1 ? autoFireInterval : initialInterval
+
+    repeat: true
+    triggeredOnStart: true
+
+    onRunningChanged: {
+        if (!running) {
+            triggerCount = 0
+        }
+    }
+
+    onTriggered: {
+        triggerCount += 1
+        fired()
+    }
+}

--- a/gpodder-ui-qml/common/GPodderCore.qml
+++ b/gpodder-ui-qml/common/GPodderCore.qml
@@ -1,0 +1,97 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2013, 2014, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+import QtQuick 2.0
+import io.thp.pyotherside 1.3
+
+
+Python {
+    id: py
+
+    property string progname: 'gpodder'
+    property bool ready: false
+    property bool refreshing: false
+
+    property string coreversion
+    property string uiversion
+    property string parserversion
+
+    signal downloadProgress(int episode_id, real progress)
+    signal playbackProgress(int episode_id, real progress)
+    signal podcastListChanged()
+    signal updatingPodcast(int podcast_id)
+    signal updatedPodcast(var podcast)
+    signal episodeListChanged(int podcast_id)
+    signal updatedEpisode(var episode)
+    signal updateStats()
+    signal configChanged(string key, var value)
+
+    Component.onCompleted: {
+        setHandler('hello', function (coreversion, uiversion, parserversion) {
+            py.coreversion = coreversion;
+            py.uiversion = uiversion;
+            py.parserversion = parserversion;
+
+            console.log('gPodder Core ' + py.coreversion);
+            console.log('gPodder QML UI ' + py.uiversion);
+            console.log('Podcastparser ' + py.parserversion);
+            console.log('PyOtherSide ' + py.pluginVersion());
+            console.log('Python ' + py.pythonVersion());
+        });
+
+        setHandler('download-progress', py.downloadProgress);
+        setHandler('playback-progress', py.playbackProgress);
+        setHandler('podcast-list-changed', py.podcastListChanged);
+        setHandler('updating-podcast', py.updatingPodcast);
+        setHandler('updated-podcast', py.updatedPodcast);
+        setHandler('refreshing', function(v) { py.refreshing = v; });
+        setHandler('episode-list-changed', py.episodeListChanged);
+        setHandler('updated-episode', py.updatedEpisode);
+        setHandler('update-stats', py.updateStats);
+        setHandler('config-changed', py.configChanged);
+
+        addImportPath(Qt.resolvedUrl('../..'));
+
+        // Load the Python side of things
+        importModule('main', function() {
+            py.call('main.initialize', [py.progname], function() {
+                py.ready = true;
+            });
+        });
+    }
+
+    function setConfig(key, value) {
+        py.call('main.set_config_value', [key, value]);
+    }
+
+    function getConfig(key, callback) {
+        py.call('main.get_config_value', [key], function (result) {
+            callback(result);
+        });
+    }
+
+    onReceived: {
+        console.log('unhandled message: ' + data);
+    }
+
+    onError: {
+        console.log('Python failure: ' + traceback);
+    }
+}

--- a/gpodder-ui-qml/common/GPodderDirectorySearchModel.qml
+++ b/gpodder-ui-qml/common/GPodderDirectorySearchModel.qml
@@ -1,0 +1,40 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2013, 2014, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+import QtQuick 2.0
+
+ListModel {
+    id: directorySearchModel
+    property string provider
+
+    function search(query, callback) {
+        clear();
+
+        py.call('main.get_directory_entries', [directorySearchModel.provider, query], function (result) {
+            for (var i=0; i<result.length; i++) {
+                directorySearchModel.append(result[i]);
+            }
+
+            if (callback !== undefined) {
+                callback();
+            }
+        });
+    }
+}

--- a/gpodder-ui-qml/common/GPodderEpisodeListModel.qml
+++ b/gpodder-ui-qml/common/GPodderEpisodeListModel.qml
@@ -26,9 +26,9 @@ import 'constants.js' as Constants
 ListModel {
     id: episodeListModel
 
-    property var podcast_id: -1
+    property int podcast_id: -1
 
-    property var cached: false
+    property bool cached: false
 
     property var queries: ({
         All: '',

--- a/gpodder-ui-qml/common/GPodderEpisodeListModel.qml
+++ b/gpodder-ui-qml/common/GPodderEpisodeListModel.qml
@@ -1,0 +1,139 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2013, 2014, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+import QtQuick 2.0
+
+import 'util.js' as Util
+import 'constants.js' as Constants
+
+ListModel {
+    id: episodeListModel
+
+    property var podcast_id: -1
+
+    property var cached: false
+
+    property var queries: ({
+        All: '',
+        Fresh: 'new or downloading',
+        Downloaded: 'downloaded or downloading',
+        UnplayedDownloads: 'downloaded and not played',
+        FinishedDownloads: 'downloaded and finished',
+        HideDeleted: 'not deleted',
+        Deleted: 'deleted',
+        ShortDownloads: 'downloaded and min > 0 and min < 10',
+    })
+
+    property var filters: ([
+        { label: qsTr("All"), query: episodeListModel.queries.All },
+        { label: qsTr("Fresh"), query: episodeListModel.queries.Fresh },
+        { label: qsTr("Downloaded"), query: episodeListModel.queries.Downloaded },
+        { label: qsTr("Unplayed downloads"), query: episodeListModel.queries.UnplayedDownloads },
+        { label: qsTr("Finished downloads"), query: episodeListModel.queries.FinishedDownloads },
+        { label: qsTr("Hide deleted"), query: episodeListModel.queries.HideDeleted },
+        { label: qsTr("Deleted episodes"), query: episodeListModel.queries.Deleted },
+        { label: qsTr("Short downloads (< 10 min)"), query: episodeListModel.queries.ShortDownloads },
+    ])
+
+    property bool ready: false
+    property int currentFilterIndex: 0
+    property string currentCustomQuery: queries.All
+
+    Component.onCompleted: {
+        // Request filter, then load episodes
+        py.call('main.get_config_value', ['ui.qml.episode_list.filter_eql'], function (result) {
+            console.debug("got query from storage: '",result,"'")
+            setQueryFromUpdate(result);
+            reload();
+        });
+    }
+
+    function forEachEpisode(callback) {
+        // Go from bottom up (= chronological order)
+        for (var i=count-1; i>=0; i--) {
+            callback(get(i));
+        }
+    }
+
+    function setQueryFromIndex(index) {
+        setQueryEx(filters[index].query,true);
+    }
+
+    function setQueryFromUpdate(query) {
+        setQueryEx(query, false);
+    }
+
+    function setQuery(query) {
+        setQueryEx(query, true);
+    }
+
+    function setQueryEx(query, update) {
+        console.info("changing query from '",currentCustomQuery,"' to '",query,"',")
+        if(query === currentCustomQuery){
+            return;
+        }
+        for (var i=0; i<filters.length; i++) {
+            if (filters[i].query === query) {                
+                currentCustomQuery = query;
+                if (update) {
+                   updateConfig();
+                }
+                currentFilterIndex = i;
+                reload();
+                return;
+            }
+        }
+        console.error("could not find query: ",query);
+    }
+
+    function updateConfig(){
+        console.info("saving selected filter: '",currentCustomQuery,"'.")
+         py.call('main.set_config_value', ['ui.qml.episode_list.filter_eql', currentCustomQuery]);
+    }
+
+    function loadAllEpisodes(callback) {
+        episodeListModel.podcast_id = -1;
+        reload(callback);
+    }
+
+    function loadEpisodes(podcast_id, callback) {
+        episodeListModel.podcast_id = podcast_id;
+        reload(callback);
+    }
+
+    function reload(callback) {
+        var query;
+        if (currentFilterIndex !== -1) {
+            query = filters[currentFilterIndex].query;
+        } else {
+            query = currentCustomQuery;
+        }
+        console.info("reloading with query: '",query,"'.")
+
+        ready = false;
+        py.call('main.load_episodes', [podcast_id, query], function (episodes) {
+            Util.updateModelFrom(episodeListModel, episodes);
+            episodeListModel.ready = true;
+            if (callback !== undefined) {
+                callback();
+            }
+        });
+    }
+}

--- a/gpodder-ui-qml/common/GPodderEpisodeListModelConnections.qml
+++ b/gpodder-ui-qml/common/GPodderEpisodeListModelConnections.qml
@@ -1,0 +1,56 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2014, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+import QtQuick 2.0
+
+import 'util.js' as Util
+
+Connections {
+    target: py
+
+    onDownloadProgress: {
+        Util.updateModelWith(episodeListModel, 'id', episode_id,
+            {'progress': progress});
+    }
+    onPlaybackProgress: {
+        Util.updateModelWith(episodeListModel, 'id', episode_id,
+            {'playbackProgress': progress});
+    }
+    onUpdatedEpisode: {
+        for (var i=0; i<episodeListModel.count; i++) {
+            if (episodeListModel.get(i).id == episode.id) {
+                episodeListModel.set(i, episode);
+                break;
+            }
+        }
+    }
+    onEpisodeListChanged: {
+        if (episodeListModel.podcast_id == podcast_id) {
+            episodeListModel.reload();
+        }
+    }
+
+    onConfigChanged: {
+        if (key === 'ui.qml.episode_list.filter_eql') {
+            episodeListModel.setQueryFromUpdate(value);
+            episodeListModel.reload();
+        }
+    }
+}

--- a/gpodder-ui-qml/common/GPodderPlatform.qml
+++ b/gpodder-ui-qml/common/GPodderPlatform.qml
@@ -1,0 +1,36 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2014, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+import QtQuick 2.0
+
+Item {
+    property bool emulatingAndroid: false
+
+    property bool android: (typeof(gpodderAndroid) !== 'undefined') || emulatingAndroid
+
+    property bool needsBackButton: !android
+
+    property bool toolbarOnTop: true
+    property bool invertedToolbar: toolbarOnTop
+    property bool titleInToolbar: toolbarOnTop
+
+    property bool floatingPlayButton: true
+    property bool hideDisabledMenu: true
+}

--- a/gpodder-ui-qml/common/GPodderPlayback.qml
+++ b/gpodder-ui-qml/common/GPodderPlayback.qml
@@ -1,0 +1,276 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2013, 2014, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+import QtQuick 2.0
+import QtMultimedia 5.0
+
+MediaPlayer {
+    id: player
+
+    property int episode: 0
+    property string episode_title: ''
+    property var episode_chapters: ([])
+    property string podcast_title: ''
+    property string cover_art: ''
+    property string episode_art: ''
+    signal playerCreated()
+
+    property var queue: ([])
+    signal queueUpdated()
+    property bool isPlaying: playbackState == MediaPlayer.PlayingState
+    property bool isPaused: playbackState == MediaPlayer.PausedState
+    property bool isStopped: playbackState == MediaPlayer.StoppedState
+
+    property bool inhibitPositionEvents: false
+    property bool seekAfterPlay: false
+    property int seekTargetSeconds: 0
+    property int lastPosition: 0
+    property int lastDuration: 0
+    property int playedFrom: 0
+
+    property var androidConnections: Connections {
+        target: platform.android ? gpodderAndroid : null
+
+        onAudioBecomingNoisy: {
+            if (playbackState === MediaPlayer.PlayingState) {
+                pause();
+            }
+        }
+    }
+
+    function togglePause() {
+        if (playbackState === MediaPlayer.PlayingState) {
+            pause();
+        } else if (playbackState === MediaPlayer.PausedState) {
+            play();
+        }
+    }
+
+    function enqueueEpisode(episode_id, callback) {
+        py.call('main.show_episode', [episode_id], function (episode) {
+            if (episode_id != player.episode && !queue.some(function (queued) {
+                return queued.episode_id === episode_id;
+            })) {
+                queue.push({
+                    episode_id: episode_id,
+                    title: episode.title,
+                });
+                queueUpdated();
+            }
+
+            if (callback !== undefined) {
+                callback();
+            }
+        });
+    }
+
+    function clearQueue() {
+        while (queue.length) {
+            queue.shift()
+        }
+        queueUpdated()
+    }
+
+    function playbackEpisode(episode_id) {
+        if (episode == episode_id) {
+            // If the episode is already loaded, just start playing
+            play();
+            return;
+        }
+
+        // First, make sure we stop any seeking / position update events
+        sendPositionToCore(lastPosition);
+        player.inhibitPositionEvents = true;
+        player.stop();
+
+        py.call('main.play_episode', [episode_id], function (episode) {
+            if (episode.video) {
+                player.inhibitPositionEvents = false;
+                Qt.openUrlExternally(episode.source);
+                return;
+            }
+
+            // Load media / prepare and start playback
+            var old_episode = player.episode;
+            player.episode = episode_id;
+            player.episode_title = episode.title;
+            player.episode_chapters = episode.chapters;
+            player.podcast_title = episode.podcast_title;
+            player.cover_art = episode.cover_art;
+            player.episode_art = episode.episode_art;
+            var source = episode.source;
+            if (source.indexOf('/') === 0) {
+                player.source = 'file://' + source;
+            } else {
+                player.source = source;
+            }
+            player.seekTargetSeconds = episode.position;
+            seekAfterPlay = true;
+
+            // Notify interested parties that the player is now active
+            if (old_episode == 0) {
+                player.playerCreated();
+            }
+
+            player.play();
+        });
+    }
+
+    function seekAndSync(target_position) {
+        sendPositionToCore(lastPosition);
+        seek(target_position);
+        playedFrom = target_position;
+        savePlaybackAfterStopTimer.restart();
+    }
+
+    onPlaybackStateChanged: {
+        if (playbackState == MediaPlayer.PlayingState) {
+            if (!seekAfterPlay) {
+                player.playedFrom = position;
+            }
+        } else {
+            sendPositionToCore(lastPosition);
+            savePlaybackAfterStopTimer.restart();
+        }
+    }
+
+    function flushToDisk() {
+        py.call('main.save_playback_state', []);
+    }
+
+    property var durationChoices: ([5, 15, 30, 45, 60])
+
+    function startSleepTimer(seconds) {
+        sleepTimer.running = false;
+        sleepTimer.secondsRemaining = seconds;
+        sleepTimer.running = true;
+    }
+
+    function stopSleepTimer() {
+        sleepTimer.running = false;
+        sleepTimer.secondsRemaining = 0;
+    }
+
+    property bool sleepTimerRunning: sleepTimer.running
+    property int sleepTimerRemaining: sleepTimer.secondsRemaining
+
+    property var sleepTimer: Timer {
+        property int secondsRemaining: 0
+
+        interval: 1000
+        repeat: true
+        onTriggered: {
+            secondsRemaining -= 1;
+
+            if (secondsRemaining <= 0) {
+                player.pause();
+                running = false;
+            }
+        }
+    }
+
+    property var nextInQueueTimer: Timer {
+        interval: 500
+
+        repeat: false
+
+        onTriggered: {
+            if (queue.length > 0) {
+                playbackEpisode(queue.shift().episode_id);
+                player.queueUpdated();
+            }
+        }
+    }
+
+    function jumpToQueueIndex(index) {
+        playbackEpisode(removeQueueIndex(index).episode_id);
+    }
+
+    function removeQueueIndex(index) {
+        var result = queue.splice(index, 1)[0];
+        player.queueUpdated();
+        return result;
+    }
+
+    onStatusChanged: {
+        if (status === MediaPlayer.EndOfMedia) {
+            nextInQueueTimer.start();
+        }
+    }
+
+    property var savePlaybackPositionTimer: Timer {
+        // Save position every minute during playback
+        interval: 60 * 1000
+        repeat: true
+        running: player.isPlaying
+        onTriggered: player.flushToDisk();
+    }
+
+    property var savePlaybackAfterStopTimer: Timer {
+        // Save position shortly after every seek and pause event
+        interval: 5 * 1000
+        repeat: false
+        onTriggered: player.flushToDisk();
+    }
+
+    property var seekAfterPlayTimer: Timer {
+        interval: 100
+        repeat: true
+        running: player.isPlaying && player.seekAfterPlay
+
+        onTriggered: {
+            var targetPosition = player.seekTargetSeconds * 1000;
+            if (Math.abs(player.position - targetPosition) < 10 * interval) {
+                // We have seeked properly
+                player.inhibitPositionEvents = false;
+                player.seekAfterPlay = false;
+            } else {
+                // Try to seek to the target position
+                player.seek(targetPosition);
+                player.playedFrom = targetPosition;
+            }
+        }
+    }
+
+    function sendPositionToCore(positionToSend) {
+        if (episode != 0 && !inhibitPositionEvents) {
+            var begin = playedFrom / 1000;
+            var end = positionToSend / 1000;
+            var duration = ((lastDuration > 0) ? lastDuration : 0) / 1000;
+            var diff = end - begin;
+
+            // Only send playback events if they are 2 seconds or longer
+            // (all other events might just be seeking events or wrong ones)
+            if (diff >= 2) {
+                py.call('main.report_playback_event', [episode, begin, end, duration]);
+            }
+        }
+    }
+
+    onPositionChanged: {
+        if (isPlaying && !inhibitPositionEvents) {
+            lastPosition = position;
+            lastDuration = duration;
+
+            // Directly update the playback progress in the episode list
+            py.playbackProgress(episode, position / duration);
+        }
+    }
+}

--- a/gpodder-ui-qml/common/GPodderPodcastListModel.qml
+++ b/gpodder-ui-qml/common/GPodderPodcastListModel.qml
@@ -1,0 +1,38 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2013, 2014, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+import QtQuick 2.0
+
+import 'util.js' as Util
+
+ListModel {
+    id: podcastListModel
+    property bool initialized: false
+
+    function reload() {
+        initialized = false;
+        py.call('main.load_podcasts', [], function (podcasts) {
+            Util.updateModelFrom(podcastListModel, podcasts);
+            if(!initialized) {
+                initialized = true;
+            }
+        });
+    }
+}

--- a/gpodder-ui-qml/common/GPodderPodcastListModelConnections.qml
+++ b/gpodder-ui-qml/common/GPodderPodcastListModelConnections.qml
@@ -1,0 +1,48 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2014, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+import QtQuick 2.0
+
+Connections {
+    target: py
+
+    onPodcastListChanged: {
+        podcastListModel.reload();
+    }
+
+    onUpdatingPodcast: {
+        for (var i=0; i<podcastListModel.count; i++) {
+            var podcast = podcastListModel.get(i);
+            if (podcast.id == podcast_id) {
+                podcastListModel.setProperty(i, 'updating', true);
+                break;
+            }
+        }
+    }
+
+    onUpdatedPodcast: {
+        for (var i=0; i<podcastListModel.count; i++) {
+            if (podcastListModel.get(i).id == podcast.id) {
+                podcastListModel.set(i, podcast);
+                break;
+            }
+        }
+    }
+}

--- a/gpodder-ui-qml/common/GPodderPodcastListModelConnections.qml
+++ b/gpodder-ui-qml/common/GPodderPodcastListModelConnections.qml
@@ -38,9 +38,10 @@ Connections {
     }
 
     onUpdatedPodcast: {
-        for (var i=0; i<podcastListModel.count; i++) {
-            if (podcastListModel.get(i).id === podcast.id) {
-                podcastListModel.set(i, podcast);
+        var model = podcastListModel;
+        for (var i=0; i<model.count; i++) {
+            if (model.get(i).id === podcast.id) {
+                model.set(i, podcast);
                 break;
             }
         }

--- a/gpodder-ui-qml/common/GPodderPodcastListModelConnections.qml
+++ b/gpodder-ui-qml/common/GPodderPodcastListModelConnections.qml
@@ -30,7 +30,7 @@ Connections {
     onUpdatingPodcast: {
         for (var i=0; i<podcastListModel.count; i++) {
             var podcast = podcastListModel.get(i);
-            if (podcast.id == podcast_id) {
+            if (podcast.id === podcast_id) {
                 podcastListModel.setProperty(i, 'updating', true);
                 break;
             }
@@ -39,7 +39,7 @@ Connections {
 
     onUpdatedPodcast: {
         for (var i=0; i<podcastListModel.count; i++) {
-            if (podcastListModel.get(i).id == podcast.id) {
+            if (podcastListModel.get(i).id === podcast.id) {
                 podcastListModel.set(i, podcast);
                 break;
             }

--- a/gpodder-ui-qml/common/constants.js
+++ b/gpodder-ui-qml/common/constants.js
@@ -1,0 +1,80 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2013, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+var layout = {
+    header: {
+        height: 100, /* page header height */
+    },
+    item: {
+        height: 80, /* podcast/episode item height */
+    },
+    coverart: 80, /* cover art size */
+    padding: 10, /* padding of items left/right */
+};
+
+var colors = {
+    download: '#7ac224', /* download green */
+    select: '#7f5785', /* gpodder dark purple */
+    fresh: '#815c86', /* gpodder purple */
+    playback: '#729fcf', /* playback blue */
+    destructive: '#cf424f', /* destructive actions */
+
+    toolbar: '#d0d0d0',
+    toolbarText: '#333333',
+    toolbarDisabled: '#666666',
+
+    inverted: {
+        toolbar: '#815c86',
+        toolbarText: '#ffffff',
+        toolbarDisabled: '#aaffffff',
+    },
+
+    page: '#dddddd',
+    dialog: '#dddddd',
+    dialogBackground: '#aa000000',
+    text: '#333333', /* text color */
+    dialogText: '#333333',
+    highlight: '#433b67',
+    dialogHighlight: '#433b67',
+    secondaryHighlight: '#605885',
+    area: '#cccccc',
+    dialogArea: '#d0d0d0',
+    toolbarArea: '#bbbbbb',
+    placeholder: '#666666',
+
+    //page: '#000000',
+    //text: '#ffffff', /* text color */
+    //highlight: Qt.lighter('#433b67', 1.2),
+    //secondaryHighlight: Qt.lighter('#605885', 1.2),
+    //area: '#333333',
+    //placeholder: '#aaaaaa',
+
+    background: '#948db3',
+    secondaryBackground: '#d0cce1',
+};
+
+var font = 'Source Sans Pro';
+
+var state = {
+    normal: 0,
+    downloaded: 1,
+    deleted: 2,
+};
+

--- a/gpodder-ui-qml/common/util.js
+++ b/gpodder-ui-qml/common/util.js
@@ -1,0 +1,87 @@
+
+/**
+ *
+ * gPodder QML UI Reference Implementation
+ * Copyright (c) 2013, Thomas Perl <m@thp.io>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+function updateModelFrom(model, data) {
+    for (var i=0; i<data.length; i++) {
+        if (model.count < i) {
+            model.append(data[i]);
+        } else {
+            model.set(i, data[i]);
+        }
+    }
+
+    while (model.count > data.length) {
+        model.remove(model.count-1);
+    }
+}
+
+function updateModelWith(model, key, value, update) {
+    for (var row=0; row<model.count; row++) {
+        var current = model.get(row);
+        if (current[key] == value) {
+            for (var key in update) {
+                model.setProperty(row, key, update[key]);
+            }
+        }
+    }
+}
+
+function formatDuration(duration) {
+    if (duration !== 0 && !duration) {
+        return ''
+    }
+
+    var h = parseInt(duration / 3600) % 24
+    var m = parseInt(duration / 60) % 60
+    var s = parseInt(duration % 60)
+
+    var hh = h > 0 ? (h < 10 ? '0' + h : h) + ':' : ''
+    var ms = (m < 10 ? '0' + m : m) + ':' + (s < 10 ? '0' + s : s)
+
+    return hh + ms
+}
+
+function formatPosition(position,duration) {
+  return formatDuration(position) + " / " + formatDuration(duration)
+}
+
+// Call a Python function and disable item until the function returns
+function disableUntilReturn(item, py, func, args) {
+    item.enabled = false;
+    py.call(func, args, function() {
+        item.enabled = true;
+    });
+}
+
+function format(s, d) {
+    return s.replace(/{([^}]*)}/g, function (m, k) {
+        return (k in d) ? d[k] : m;
+    });
+}
+
+function atMostOnce(callback) {
+    var called = false;
+    return function () {
+        if (!called) {
+            called = true;
+            callback();
+        }
+    };
+}

--- a/gpodder-ui-qml/makefile
+++ b/gpodder-ui-qml/makefile
@@ -1,0 +1,21 @@
+PROJECT := gpodder-ui-qml
+VERSION := 4.11.1
+
+all:
+	@echo ""
+	@echo "  make release ..... Build source release"
+	@echo ""
+
+release: dist/$(PROJECT)-$(VERSION).tar.gz
+
+dist/$(PROJECT)-$(VERSION).tar.gz:
+	mkdir -p dist
+	git archive --format=tar --prefix=$(PROJECT)-$(VERSION)/ $(VERSION) | gzip >$@
+
+clean:
+	find . -name '__pycache__' -exec rm -rf {} +
+
+distclean: clean
+	rm -rf dist
+
+.PHONY: all release clean

--- a/gpodder-ui-qml/setup.cfg
+++ b/gpodder-ui-qml/setup.cfg
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length = 120

--- a/qml/AllEpisodesPage.qml
+++ b/qml/AllEpisodesPage.qml
@@ -31,8 +31,9 @@ Page {
     onStatusChanged: pgst.handlePageStatusChange(status)
 
     Component.onCompleted: {
-        episodeListModel.setQuery(episodeListModel.queries.Downloaded);
-        episodeListModel.reload();
+        py.getConfig('ui.qml.episode_list.filter_eql', function (value) {
+            episodeListModel.setQuery(value);
+        });
     }
 
     BusyIndicator {
@@ -47,6 +48,17 @@ Page {
 
         PullDownMenu {
             EpisodeListFilterItem { id: filterItem; model: episodeListModel }
+
+            MenuItem {
+                text: py.refreshing ? qsTr("Checking for new episodes...") : qsTr("Check for new episodes")
+                enabled: podcastListModel.count > 0 && !py.refreshing
+                onClicked: {
+                    episodeListModel.ready = false;
+                    py.call('main.check_for_episodes',[],function (){
+                        episodeListModel.reload();
+                    });
+                }
+            }
         }
 
         VerticalScrollDecorator { flickable: filteredEpisodesList }

--- a/qml/EpisodeFilterDialog.qml
+++ b/qml/EpisodeFilterDialog.qml
@@ -48,9 +48,9 @@ Page {
 
             highlighted: down || (index == filterSelector.selectedIndex)
 
-            onClicked: {
-                filterSelector.model.currentFilterIndex = index;
-                filterSelector.model.reload();
+            onClicked: {      
+                console.debug("Selected filter id ", index)
+                filterSelector.model.setQueryFromIndex(index);
                 pageStack.pop();
             }
 

--- a/qml/PodcastsPage.qml
+++ b/qml/PodcastsPage.qml
@@ -83,12 +83,19 @@ Page {
 
         model: podcastListModel
 
+        BusyIndicator {
+            size: BusyIndicatorSize.Large
+            anchors.centerIn: parent
+            visible: !podcastListModel.initialized
+            running: visible
+        }
+
         delegate: PodcastItem {
             onClicked: pgst.loadPage('EpisodesPage.qml', {'podcast_id': id, 'title': title});
         }
 
         ViewPlaceholder {
-            enabled: podcastListModel.count === 0 && podcastListModel.firstRun
+            enabled: podcastListModel.count === 0 && podcastListModel.initialized
             text: qsTr("No subscriptions")
         }
     }

--- a/translations/harbour-org.gpodder.sailfish-bg.ts
+++ b/translations/harbour-org.gpodder.sailfish-bg.ts
@@ -32,14 +32,24 @@
 <context>
     <name>AllEpisodesPage</name>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="55"/>
-        <source>Episodes: </source>
-        <translation>Епизоди: </translation>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Checking for new episodes...</source>
+        <translation type="unfinished">Проверява се за нови...</translation>
     </message>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="71"/>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Check for new episodes</source>
+        <translation type="unfinished">Проверяване за нови епизоди</translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="67"/>
+        <source>Episodes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="83"/>
         <source>No episodes found</source>
-        <translation>Няма намерени епизоди</translation>
+        <translation type="unfinished">Няма намерени епизоди</translation>
     </message>
 </context>
 <context>
@@ -171,42 +181,42 @@
 <context>
     <name>GPodderEpisodeListModel</name>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="43"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
         <source>All</source>
         <translation>Всички</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="44"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
         <source>Fresh</source>
         <translation>Нови и неизтеглени</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
         <source>Downloaded</source>
         <translation>Изтеглени</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
         <source>Unplayed downloads</source>
         <translation>Непускани епизоди</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
         <source>Finished downloads</source>
         <translation>Изслушани епизоди</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
         <source>Hide deleted</source>
         <translation>Без изтритите</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="51"/>
         <source>Deleted episodes</source>
         <translation>Изтрити епизоди</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="52"/>
         <source>Short downloads (&lt; 10 min)</source>
         <translation>Кратки епизоди (&lt; 10 мин)</translation>
     </message>
@@ -339,12 +349,17 @@
         <translation>+ 1 мин</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="242"/>
+        <location filename="../qml/PlayerPage.qml" line="241"/>
+        <source>rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/PlayerPage.qml" line="251"/>
         <source>Queue</source>
         <translation>Опашка</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="266"/>
+        <location filename="../qml/PlayerPage.qml" line="275"/>
         <source>Remove from queue</source>
         <translation>Премахване от опашката</translation>
     </message>
@@ -504,7 +519,7 @@
         <translation>Абонаменти</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastsPage.qml" line="92"/>
+        <location filename="../qml/PodcastsPage.qml" line="99"/>
         <source>No subscriptions</source>
         <translation>Няма абонаменти</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-de.ts
+++ b/translations/harbour-org.gpodder.sailfish-de.ts
@@ -32,14 +32,24 @@
 <context>
     <name>AllEpisodesPage</name>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="55"/>
-        <source>Episodes: </source>
-        <translation>Episoden: </translation>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Checking for new episodes...</source>
+        <translation type="unfinished">Suche neue Episoden...</translation>
     </message>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="71"/>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Check for new episodes</source>
+        <translation type="unfinished">Auf neue Episoden prüfen</translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="67"/>
+        <source>Episodes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="83"/>
         <source>No episodes found</source>
-        <translation>Keine Episoden gefunden</translation>
+        <translation type="unfinished">Keine Episoden gefunden</translation>
     </message>
 </context>
 <context>
@@ -171,42 +181,42 @@
 <context>
     <name>GPodderEpisodeListModel</name>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="43"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
         <source>All</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="44"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
         <source>Fresh</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
         <source>Downloaded</source>
         <translation>Heruntergeladen</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
         <source>Unplayed downloads</source>
         <translation>Heruntergeladen &amp; Nicht abgespielt</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
         <source>Finished downloads</source>
         <translation>Heruntergeladen &amp; Fertig</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
         <source>Hide deleted</source>
         <translation>Gelöschte ausblenden</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="51"/>
         <source>Deleted episodes</source>
         <translation>Gelöscht</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="52"/>
         <source>Short downloads (&lt; 10 min)</source>
         <translation>Heruntergeladen &amp; Länge &lt; 10min</translation>
     </message>
@@ -339,12 +349,17 @@
         <translation>+ 1 min</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="242"/>
+        <location filename="../qml/PlayerPage.qml" line="241"/>
+        <source>rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/PlayerPage.qml" line="251"/>
         <source>Queue</source>
         <translation>Playliste</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="266"/>
+        <location filename="../qml/PlayerPage.qml" line="275"/>
         <source>Remove from queue</source>
         <translation>Von Playliste entfernen</translation>
     </message>
@@ -504,7 +519,7 @@
         <translation>Abonnierte Podcasts</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastsPage.qml" line="92"/>
+        <location filename="../qml/PodcastsPage.qml" line="99"/>
         <source>No subscriptions</source>
         <translation>Keine abonnierten Podcasts</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-es.ts
+++ b/translations/harbour-org.gpodder.sailfish-es.ts
@@ -32,14 +32,24 @@
 <context>
     <name>AllEpisodesPage</name>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="55"/>
-        <source>Episodes: </source>
-        <translation>Episodios: </translation>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Checking for new episodes...</source>
+        <translation type="unfinished">Buscando nuevos episodios...</translation>
     </message>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="71"/>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Check for new episodes</source>
+        <translation type="unfinished">Buscar nuevos episodios</translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="67"/>
+        <source>Episodes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="83"/>
         <source>No episodes found</source>
-        <translation>No se han encontrado episodios</translation>
+        <translation type="unfinished">No se han encontrado episodios</translation>
     </message>
 </context>
 <context>
@@ -171,42 +181,42 @@
 <context>
     <name>GPodderEpisodeListModel</name>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="43"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
         <source>All</source>
         <translation>Todos</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="44"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
         <source>Fresh</source>
         <translation>Nuevos</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
         <source>Downloaded</source>
         <translation>Descargados</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
         <source>Unplayed downloads</source>
         <translation>Descargas sin reproducir</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
         <source>Finished downloads</source>
         <translation>Descargas reproducidas</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
         <source>Hide deleted</source>
         <translation>Ocultar borrados</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="51"/>
         <source>Deleted episodes</source>
         <translation>Episodios borrados</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="52"/>
         <source>Short downloads (&lt; 10 min)</source>
         <translation>Descargas cortas ( &lt; 10 min)</translation>
     </message>
@@ -339,12 +349,17 @@
         <translation>+ 1 min</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="242"/>
+        <location filename="../qml/PlayerPage.qml" line="241"/>
+        <source>rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/PlayerPage.qml" line="251"/>
         <source>Queue</source>
         <translation>En cola</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="266"/>
+        <location filename="../qml/PlayerPage.qml" line="275"/>
         <source>Remove from queue</source>
         <translation>Eliminar de la cola</translation>
     </message>
@@ -504,7 +519,7 @@
         <translation>Suscripciones</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastsPage.qml" line="92"/>
+        <location filename="../qml/PodcastsPage.qml" line="99"/>
         <source>No subscriptions</source>
         <translation>No hay suscripciones</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-it.ts
+++ b/translations/harbour-org.gpodder.sailfish-it.ts
@@ -32,14 +32,24 @@
 <context>
     <name>AllEpisodesPage</name>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="55"/>
-        <source>Episodes: </source>
-        <translation>Episodi: </translation>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Checking for new episodes...</source>
+        <translation type="unfinished">Controllo nuovi episodi...</translation>
     </message>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="71"/>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Check for new episodes</source>
+        <translation type="unfinished">Controlla nuovi episodi</translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="67"/>
+        <source>Episodes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="83"/>
         <source>No episodes found</source>
-        <translation>Nessun episodio</translation>
+        <translation type="unfinished">Nessun episodio</translation>
     </message>
 </context>
 <context>
@@ -171,42 +181,42 @@
 <context>
     <name>GPodderEpisodeListModel</name>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="43"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
         <source>All</source>
         <translation>Tutti</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="44"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
         <source>Fresh</source>
         <translation>Nuovi</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
         <source>Downloaded</source>
         <translation>Scaricati</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
         <source>Unplayed downloads</source>
         <translation>Download non riprodotti</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
         <source>Finished downloads</source>
         <translation>Download completati</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
         <source>Hide deleted</source>
         <translation>Nascondi eliminati</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="51"/>
         <source>Deleted episodes</source>
         <translation>Episodi eliminati</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="52"/>
         <source>Short downloads (&lt; 10 min)</source>
         <translation>Download corti (&lt; 10 min)</translation>
     </message>
@@ -339,12 +349,17 @@
         <translation>+ 1 min</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="242"/>
+        <location filename="../qml/PlayerPage.qml" line="241"/>
+        <source>rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/PlayerPage.qml" line="251"/>
         <source>Queue</source>
         <translation>Coda</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="266"/>
+        <location filename="../qml/PlayerPage.qml" line="275"/>
         <source>Remove from queue</source>
         <translation>Rimuovi dalla coda</translation>
     </message>
@@ -504,7 +519,7 @@
         <translation>iscrizioni</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastsPage.qml" line="92"/>
+        <location filename="../qml/PodcastsPage.qml" line="99"/>
         <source>No subscriptions</source>
         <translation>Nessuna iscrizione</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-pl.ts
+++ b/translations/harbour-org.gpodder.sailfish-pl.ts
@@ -32,14 +32,24 @@
 <context>
     <name>AllEpisodesPage</name>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="55"/>
-        <source>Episodes: </source>
-        <translation>Odcinki:</translation>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Checking for new episodes...</source>
+        <translation type="unfinished">Szukanie nowych odcinków...</translation>
     </message>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="71"/>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Check for new episodes</source>
+        <translation type="unfinished">Szukaj nowych odcinków</translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="67"/>
+        <source>Episodes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="83"/>
         <source>No episodes found</source>
-        <translation>Brak odcinków</translation>
+        <translation type="unfinished">Brak odcinków</translation>
     </message>
 </context>
 <context>
@@ -171,42 +181,42 @@
 <context>
     <name>GPodderEpisodeListModel</name>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="43"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
         <source>All</source>
         <translation>Wszytskie</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="44"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
         <source>Fresh</source>
         <translation>Nowe</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
         <source>Downloaded</source>
         <translation>Pobrane</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
         <source>Unplayed downloads</source>
         <translation>Nieodtworzone pobrane</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
         <source>Finished downloads</source>
         <translation>Zakończone pobrania</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
         <source>Hide deleted</source>
         <translation>Ukryj usunięte</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="51"/>
         <source>Deleted episodes</source>
         <translation>Usunięte odcinki</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="52"/>
         <source>Short downloads (&lt; 10 min)</source>
         <translation>Krótkie pobrane (&lt; 10min)</translation>
     </message>
@@ -339,12 +349,17 @@
         <translation>+ 1 min</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="242"/>
+        <location filename="../qml/PlayerPage.qml" line="241"/>
+        <source>rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/PlayerPage.qml" line="251"/>
         <source>Queue</source>
         <translation>Koleka</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="266"/>
+        <location filename="../qml/PlayerPage.qml" line="275"/>
         <source>Remove from queue</source>
         <translation>Usuń z kolejki</translation>
     </message>
@@ -504,7 +519,7 @@
         <translation>Subskrypcje</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastsPage.qml" line="92"/>
+        <location filename="../qml/PodcastsPage.qml" line="99"/>
         <source>No subscriptions</source>
         <translation>Brak subskrybcji</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-ru.ts
+++ b/translations/harbour-org.gpodder.sailfish-ru.ts
@@ -32,14 +32,24 @@
 <context>
     <name>AllEpisodesPage</name>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="55"/>
-        <source>Episodes: </source>
-        <translation>Выпуски: </translation>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Checking for new episodes...</source>
+        <translation type="unfinished">Проверка новых выпусков...</translation>
     </message>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="71"/>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Check for new episodes</source>
+        <translation type="unfinished">Проверить новые выпуски</translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="67"/>
+        <source>Episodes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="83"/>
         <source>No episodes found</source>
-        <translation>Нет выпусков</translation>
+        <translation type="unfinished">Нет выпусков</translation>
     </message>
 </context>
 <context>
@@ -171,42 +181,42 @@
 <context>
     <name>GPodderEpisodeListModel</name>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="43"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
         <source>All</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="44"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
         <source>Fresh</source>
         <translation>Последние</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
         <source>Downloaded</source>
         <translation>Скачанные</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
         <source>Unplayed downloads</source>
         <translation>Непрослушанные</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
         <source>Finished downloads</source>
         <translation>Завершенные закачки</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
         <source>Hide deleted</source>
         <translation>Скрыть удаленные</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="51"/>
         <source>Deleted episodes</source>
         <translation>Удаленные выпуски</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="52"/>
         <source>Short downloads (&lt; 10 min)</source>
         <translation>Короткие (&lt; 10 минут)</translation>
     </message>
@@ -339,12 +349,17 @@
         <translation>+ 1 мин</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="242"/>
+        <location filename="../qml/PlayerPage.qml" line="241"/>
+        <source>rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/PlayerPage.qml" line="251"/>
         <source>Queue</source>
         <translation>Очередь</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="266"/>
+        <location filename="../qml/PlayerPage.qml" line="275"/>
         <source>Remove from queue</source>
         <translation>Убрать из очереди</translation>
     </message>
@@ -504,7 +519,7 @@
         <translation>Подписки</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastsPage.qml" line="92"/>
+        <location filename="../qml/PodcastsPage.qml" line="99"/>
         <source>No subscriptions</source>
         <translation>Нет подписок</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-sv.ts
+++ b/translations/harbour-org.gpodder.sailfish-sv.ts
@@ -32,14 +32,24 @@
 <context>
     <name>AllEpisodesPage</name>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="55"/>
-        <source>Episodes: </source>
-        <translation>Avsnitt: </translation>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Checking for new episodes...</source>
+        <translation type="unfinished">Söker nya avsnitt...</translation>
     </message>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="71"/>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Check for new episodes</source>
+        <translation type="unfinished">Sök efter nya avsnitt</translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="67"/>
+        <source>Episodes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="83"/>
         <source>No episodes found</source>
-        <translation>Inga avsnitt hittades</translation>
+        <translation type="unfinished">Inga avsnitt hittades</translation>
     </message>
 </context>
 <context>
@@ -171,42 +181,42 @@
 <context>
     <name>GPodderEpisodeListModel</name>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="43"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
         <source>All</source>
         <translation>Alla</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="44"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
         <source>Fresh</source>
         <translation>Nya</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
         <source>Downloaded</source>
         <translation>Nerladdat</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
         <source>Unplayed downloads</source>
         <translation>Ospelade nerladdningar</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
         <source>Finished downloads</source>
         <translation>Slutförda nerladdningar</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
         <source>Hide deleted</source>
         <translation>Dölj borttagna</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="51"/>
         <source>Deleted episodes</source>
         <translation>Borttagna avsnitt</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="52"/>
         <source>Short downloads (&lt; 10 min)</source>
         <translation>Korta nerladdningar (&lt;10 min)</translation>
     </message>
@@ -339,12 +349,17 @@
         <translation>+ 1 min</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="242"/>
+        <location filename="../qml/PlayerPage.qml" line="241"/>
+        <source>rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/PlayerPage.qml" line="251"/>
         <source>Queue</source>
         <translation>Köa</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="266"/>
+        <location filename="../qml/PlayerPage.qml" line="275"/>
         <source>Remove from queue</source>
         <translation>Ta bort från kön</translation>
     </message>
@@ -504,7 +519,7 @@
         <translation>Prenumerationer</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastsPage.qml" line="92"/>
+        <location filename="../qml/PodcastsPage.qml" line="99"/>
         <source>No subscriptions</source>
         <translation>Inga prenumerationer</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-zh_CN.ts
+++ b/translations/harbour-org.gpodder.sailfish-zh_CN.ts
@@ -32,14 +32,24 @@
 <context>
     <name>AllEpisodesPage</name>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="55"/>
-        <source>Episodes: </source>
-        <translation>剧集：</translation>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Checking for new episodes...</source>
+        <translation type="unfinished">正在检测新剧集……</translation>
     </message>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="71"/>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Check for new episodes</source>
+        <translation type="unfinished">检测新剧集</translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="67"/>
+        <source>Episodes: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="83"/>
         <source>No episodes found</source>
-        <translation>没有找到剧集</translation>
+        <translation type="unfinished">没有找到剧集</translation>
     </message>
 </context>
 <context>
@@ -171,42 +181,42 @@
 <context>
     <name>GPodderEpisodeListModel</name>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="43"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
         <source>All</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="44"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
         <source>Fresh</source>
         <translation>新的</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
         <source>Downloaded</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
         <source>Unplayed downloads</source>
         <translation>未播放的下载</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
         <source>Finished downloads</source>
         <translation>已完成的下载</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
         <source>Hide deleted</source>
         <translation>隐藏已删除</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="51"/>
         <source>Deleted episodes</source>
         <translation>已删除剧集</translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="52"/>
         <source>Short downloads (&lt; 10 min)</source>
         <translation>较短的下载（10分钟以内）</translation>
     </message>
@@ -339,12 +349,17 @@
         <translation>+1分钟</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="242"/>
+        <location filename="../qml/PlayerPage.qml" line="241"/>
+        <source>rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/PlayerPage.qml" line="251"/>
         <source>Queue</source>
         <translation>队列</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="266"/>
+        <location filename="../qml/PlayerPage.qml" line="275"/>
         <source>Remove from queue</source>
         <translation>从队列移除</translation>
     </message>
@@ -504,7 +519,7 @@
         <translation>订阅</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastsPage.qml" line="92"/>
+        <location filename="../qml/PodcastsPage.qml" line="99"/>
         <source>No subscriptions</source>
         <translation>无订阅</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish.ts
+++ b/translations/harbour-org.gpodder.sailfish.ts
@@ -32,12 +32,22 @@
 <context>
     <name>AllEpisodesPage</name>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="55"/>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Checking for new episodes...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="53"/>
+        <source>Check for new episodes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AllEpisodesPage.qml" line="67"/>
         <source>Episodes: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AllEpisodesPage.qml" line="71"/>
+        <location filename="../qml/AllEpisodesPage.qml" line="83"/>
         <source>No episodes found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -171,42 +181,42 @@
 <context>
     <name>GPodderEpisodeListModel</name>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="43"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="44"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
         <source>Fresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="45"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
         <source>Downloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="46"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
         <source>Unplayed downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="47"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
         <source>Finished downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="48"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
         <source>Hide deleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="49"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="51"/>
         <source>Deleted episodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="50"/>
+        <location filename="../gpodder-ui-qml/common/GPodderEpisodeListModel.qml" line="52"/>
         <source>Short downloads (&lt; 10 min)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -339,12 +349,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="242"/>
+        <location filename="../qml/PlayerPage.qml" line="241"/>
+        <source>rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/PlayerPage.qml" line="251"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="266"/>
+        <location filename="../qml/PlayerPage.qml" line="275"/>
         <source>Remove from queue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -504,7 +519,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PodcastsPage.qml" line="92"/>
+        <location filename="../qml/PodcastsPage.qml" line="99"/>
         <source>No subscriptions</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Things done:
 - removed gpodder-ui-qml submodule (took #93 as hint)
 - added loading indicator to podcast list, when podcasts not yet loaded
 - persisting used filter for episodelist actually to config and using it
 - added refresh option to episodelist and added loading indicator

If accepted, the folder of the former submodule should be renamed probably.

also fixes #37 

I tried to capture it a bit:

![output](https://user-images.githubusercontent.com/7593137/93687965-8dede900-fac2-11ea-87dc-ba4f6c774bb6.gif)
