### PR TITLE
added github action build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Gpodder build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Prepare
+      run: mkdir output
+
+    - name: Build armv7hl
+      id: build_armv7hl
+      uses: coderus/github-sfos-build@master
+      with:
+        release: 3.3.0.14
+      
+    - name: Upload build result
+      uses: actions/upload-artifact@v2
+      with:
+        name: gpodder-rpms
+        path: RPMS
+
+    - name: Create release
+      if: contains(github.ref, 'release')
+      run: |
+        set -x
+        assets=()
+        for asset in RPMS/*.rpm; do
+          assets+=("-a" "$asset")
+        done
+        tag_name="${GITHUB_REF##*/}"
+        hub release create "${assets[@]}" -m "$tag_name" "$tag_name"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Proof-of-Concept github builds the rpm automatically.
Can be seen on my master branch: https://github.com/thigg/gpodder-sailfish/actions

Sources: https://github.com/CODeRUS/screencast/blob/master/.github/workflows/build.yml, https://forum.sailfishos.org/t/build-sailfish-os-application-using-github-actions-or-gitlab-ci/2147