### PR TITLE
Add python3-sqlite dependency

### DIFF
--- a/rpm/harbour-org.gpodder.sailfish.spec
+++ b/rpm/harbour-org.gpodder.sailfish.spec
@@ -19,6 +19,7 @@ Requires:   pyotherside-qml-plugin-python3-qt5 >= 1.3.0
 Requires:   sailfishsilica-qt5
 Requires:   libsailfishapp-launcher
 Requires:   mpris-qt5
+Requires:   python3-sqlite
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 
 %description


### PR DESCRIPTION
(lib normally provided with the OS but this should prevent snafus like the SFOS 3.4.0.22 update)