### PR TITLE
set python default loglevel to info

### DIFF
--- a/common/main.py
+++ b/common/main.py
@@ -41,7 +41,7 @@ import datetime
 import re
 
 logger = logging.getLogger(__name__)
-
+logging.basicConfig(level=logging.INFO)
 
 def run_in_background_thread(f):
     """Decorator for functions that take longer to finish


### PR DESCRIPTION
previously messages from minidb were spamming the journal with everything it was doing. 
If you did a podcast import, the whole feed was dumped into the journal.

This isn't based on the most up-to-date master, as I cant deploy it in my emulator.

previously part of #140