### PR TITLE
enable async image loading

### DIFF
--- a/qml/ArtArea.qml
+++ b/qml/ArtArea.qml
@@ -5,6 +5,7 @@ Item {
     Image {
         id: episodeArtArea
         visible: episode_art || cover_art ? true : false
+        asynchronous: true
 
         anchors {
             left: parent.left
@@ -18,6 +19,7 @@ Item {
     Image {
         id: podcastArtArea
         visible: episode_art && cover_art ? true : false
+        asynchronous: true
 
         anchors {
             right: parent.right

--- a/qml/CoverContainer.qml
+++ b/qml/CoverContainer.qml
@@ -31,6 +31,7 @@ CoverBackground {
         anchors.horizontalCenter: parent.horizontalCenter
         width: parent.width
         height: sourceSize.height * width / sourceSize.width
+        asynchronous: true
     }
 
     PodcastsCover {

--- a/qml/DirectoryItem.qml
+++ b/qml/DirectoryItem.qml
@@ -34,6 +34,7 @@ ListItem {
 
     Image {
         id: cover
+        asynchronous: true
         opacity: image && status == Image.Ready
         Behavior on opacity { FadeAnimation { } }
 

--- a/qml/PodcastDetail.qml
+++ b/qml/PodcastDetail.qml
@@ -95,6 +95,7 @@ Page {
 
                 Image {
                     id: coverImage
+                    asynchronous: true
                     source: podcastDetail.coverart
                     fillMode: Image.PreserveAspectFit
                     width: parent.width

--- a/qml/PodcastItem.qml
+++ b/qml/PodcastItem.qml
@@ -104,6 +104,7 @@ ListItem {
     Image {
         id: cover
         visible: !updating && coverart
+        asynchronous: true
 
         anchors {
             left: parent.left

--- a/translations/harbour-org.gpodder.sailfish-bg.ts
+++ b/translations/harbour-org.gpodder.sailfish-bg.ts
@@ -367,18 +367,18 @@
         <translation>Детайли</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="135"/>
+        <location filename="../qml/PodcastDetail.qml" line="136"/>
         <source>Section: </source>
         <translation>Раздел: </translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="167"/>
-        <location filename="../qml/PodcastDetail.qml" line="202"/>
+        <location filename="../qml/PodcastDetail.qml" line="168"/>
+        <location filename="../qml/PodcastDetail.qml" line="203"/>
         <source>Edit Section</source>
         <translation>Редактиране на раздел</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="203"/>
+        <location filename="../qml/PodcastDetail.qml" line="204"/>
         <source>Save</source>
         <translation>Записване</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-de.ts
+++ b/translations/harbour-org.gpodder.sailfish-de.ts
@@ -367,18 +367,18 @@
         <translation>Podcast Information</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="135"/>
+        <location filename="../qml/PodcastDetail.qml" line="136"/>
         <source>Section: </source>
         <translation>Kategorie: </translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="167"/>
-        <location filename="../qml/PodcastDetail.qml" line="202"/>
+        <location filename="../qml/PodcastDetail.qml" line="168"/>
+        <location filename="../qml/PodcastDetail.qml" line="203"/>
         <source>Edit Section</source>
         <translation>Kategorie editieren</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="203"/>
+        <location filename="../qml/PodcastDetail.qml" line="204"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-es.ts
+++ b/translations/harbour-org.gpodder.sailfish-es.ts
@@ -367,18 +367,18 @@
         <translation>Detalles del podcast</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="135"/>
+        <location filename="../qml/PodcastDetail.qml" line="136"/>
         <source>Section: </source>
         <translation>Sección: </translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="167"/>
-        <location filename="../qml/PodcastDetail.qml" line="202"/>
+        <location filename="../qml/PodcastDetail.qml" line="168"/>
+        <location filename="../qml/PodcastDetail.qml" line="203"/>
         <source>Edit Section</source>
         <translation>Editar sección</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="203"/>
+        <location filename="../qml/PodcastDetail.qml" line="204"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-it.ts
+++ b/translations/harbour-org.gpodder.sailfish-it.ts
@@ -367,18 +367,18 @@
         <translation>Dettagli podcast</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="135"/>
+        <location filename="../qml/PodcastDetail.qml" line="136"/>
         <source>Section: </source>
         <translation>Sezione: </translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="167"/>
-        <location filename="../qml/PodcastDetail.qml" line="202"/>
+        <location filename="../qml/PodcastDetail.qml" line="168"/>
+        <location filename="../qml/PodcastDetail.qml" line="203"/>
         <source>Edit Section</source>
         <translation>Modifica sezione</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="203"/>
+        <location filename="../qml/PodcastDetail.qml" line="204"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-pl.ts
+++ b/translations/harbour-org.gpodder.sailfish-pl.ts
@@ -367,18 +367,18 @@
         <translation>Szczegóły podcastu</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="135"/>
+        <location filename="../qml/PodcastDetail.qml" line="136"/>
         <source>Section: </source>
         <translation>Rozdział: </translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="167"/>
-        <location filename="../qml/PodcastDetail.qml" line="202"/>
+        <location filename="../qml/PodcastDetail.qml" line="168"/>
+        <location filename="../qml/PodcastDetail.qml" line="203"/>
         <source>Edit Section</source>
         <translation>Edytuj rodział</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="203"/>
+        <location filename="../qml/PodcastDetail.qml" line="204"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-ru.ts
+++ b/translations/harbour-org.gpodder.sailfish-ru.ts
@@ -367,18 +367,18 @@
         <translation>Описание</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="135"/>
+        <location filename="../qml/PodcastDetail.qml" line="136"/>
         <source>Section: </source>
         <translation>Раздел: </translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="167"/>
-        <location filename="../qml/PodcastDetail.qml" line="202"/>
+        <location filename="../qml/PodcastDetail.qml" line="168"/>
+        <location filename="../qml/PodcastDetail.qml" line="203"/>
         <source>Edit Section</source>
         <translation>Изменить раздел</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="203"/>
+        <location filename="../qml/PodcastDetail.qml" line="204"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-sv.ts
+++ b/translations/harbour-org.gpodder.sailfish-sv.ts
@@ -367,18 +367,18 @@
         <translation>Poddinformation</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="135"/>
+        <location filename="../qml/PodcastDetail.qml" line="136"/>
         <source>Section: </source>
         <translation>Sektion: </translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="167"/>
-        <location filename="../qml/PodcastDetail.qml" line="202"/>
+        <location filename="../qml/PodcastDetail.qml" line="168"/>
+        <location filename="../qml/PodcastDetail.qml" line="203"/>
         <source>Edit Section</source>
         <translation>Redigera sektion</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="203"/>
+        <location filename="../qml/PodcastDetail.qml" line="204"/>
         <source>Save</source>
         <translation>Spara</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish-zh_CN.ts
+++ b/translations/harbour-org.gpodder.sailfish-zh_CN.ts
@@ -367,18 +367,18 @@
         <translation>播客详情</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="135"/>
+        <location filename="../qml/PodcastDetail.qml" line="136"/>
         <source>Section: </source>
         <translation>片段：</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="167"/>
-        <location filename="../qml/PodcastDetail.qml" line="202"/>
+        <location filename="../qml/PodcastDetail.qml" line="168"/>
+        <location filename="../qml/PodcastDetail.qml" line="203"/>
         <source>Edit Section</source>
         <translation>编辑片段</translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="203"/>
+        <location filename="../qml/PodcastDetail.qml" line="204"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>

--- a/translations/harbour-org.gpodder.sailfish.ts
+++ b/translations/harbour-org.gpodder.sailfish.ts
@@ -367,18 +367,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="135"/>
+        <location filename="../qml/PodcastDetail.qml" line="136"/>
         <source>Section: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="167"/>
-        <location filename="../qml/PodcastDetail.qml" line="202"/>
+        <location filename="../qml/PodcastDetail.qml" line="168"/>
+        <location filename="../qml/PodcastDetail.qml" line="203"/>
         <source>Edit Section</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PodcastDetail.qml" line="203"/>
+        <location filename="../qml/PodcastDetail.qml" line="204"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Just a small improvement, I stumbled upon it at https://doc.qt.io/qt-5/qtquick-performance.html#asynchronous-loading

I saw an effect once on my phone, where the last 2 images of the episodelist loaded after everything was displayed.

As far as I can see, this should provide benefits only and should have no downside for gpodder.

This isn't based on the most up-to-date master, as I cant deploy it in my emulator.