### PR TITLE
Config option to allow downloads via wifi only

### DIFF
--- a/qml/ConnectionBlockedDialog.qml
+++ b/qml/ConnectionBlockedDialog.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+
+ Dialog {
+     property var callback
+
+     Column {
+         width: parent.width
+
+         DialogHeader {
+             title: "Connection blocked"
+         }
+         Label{
+             text: "Make an exception for now?"
+         }
+     }
+
+     onAccepted: {
+         callback();
+     }
+
+ }

--- a/qml/EpisodeItem.qml
+++ b/qml/EpisodeItem.qml
@@ -28,6 +28,7 @@ ListItem {
     id: episodeItem
     property bool isPlaying: ((player.episode === id) && player.isPlaying)
     property variant mime: mime_type.split('/')
+    property var downloaded: downloadState === 1
 
     Rectangle {
         anchors.fill: parent
@@ -73,8 +74,16 @@ ListItem {
                     if (episodeItem.isPlaying) {
                         player.pause();
                     } else {
-                        player.playbackEpisode(id);
+                        if(downloaded === false){
+                            connectionUtil.executeIfConnectionAllowed(doPlayback)
+                        }else {
+                            doPlayback();
+                        }
                     }
+                }
+
+                function doPlayback(){
+                    player.playbackEpisode(id);
                 }
             }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -20,8 +20,10 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import Nemo.Configuration 1.0
 
 import 'common'
+import 'utils'
 
 PodcastsPage {
     id: pgst
@@ -72,6 +74,10 @@ PodcastsPage {
     MprisPlayer {}
     MediaKeys {}
 
+    ConnectionUtil {
+        id: connectionUtil
+    }
+
     GPodderPodcastListModel { id: podcastListModel }
     GPodderPodcastListModelConnections {}
 
@@ -99,4 +105,11 @@ PodcastsPage {
         visible: !py.ready
         running: visible
     }
+
+    ConfigurationValue {
+        id: configCellularDownloadsEnabled
+        key: "/apps/ControlPanel/gpodder/cellularDownloadsEnabled"
+        defaultValue: false
+    }
+
 }

--- a/qml/SettingsPage.qml
+++ b/qml/SettingsPage.qml
@@ -35,10 +35,12 @@ Page {
             py.getConfig('limit.episodes', function (value) {
                 limit_episodes.value = value;
             });
+            cellularDownloadsEnabled.checked = configCellularDownloadsEnabled.value;
         } else if (status === PageStatus.Deactivating) {
             py.setConfig('plugins.youtube.api_key_v3', youtube_api_key_v3.text);
             py.setConfig('limit.episodes', parseInt(limit_episodes.value));
             youtube_api_key_v3.focus = false;
+            configCellularDownloadsEnabled.value = cellularDownloadsEnabled.checked
         }
     }
 
@@ -92,6 +94,13 @@ Page {
                 maximumValue: 1000
                 stepSize: 100
             }
+
+            TextSwitch {
+                id: cellularDownloadsEnabled
+                text: qsTr("Allow Downloads via mobile data")
+                checked: configCellularDownloadsEnabled.value
+            }
+
         }
     }
 }

--- a/qml/utils/ConnectionUtils.qml
+++ b/qml/utils/ConnectionUtils.qml
@@ -1,0 +1,50 @@
+import QtQuick 2.0
+import Nemo.DBus 2.0
+
+QtObject {
+    property DBusInterface connmanWifi: DBusInterface {
+          bus: DBus.SystemBus
+          service: "net.connman"
+          path: "/net/connman/technology/wifi"
+          iface: "net.connman.Technology"
+
+          property bool wifiConnected
+
+          signalsEnabled: true
+          function propertyChanged(name, value) {
+              if (name === "Connected") {
+                  wifiConnected = value
+              }
+          }
+
+          function getProperties() {
+              typedCall('GetProperties', undefined, function(result) {
+                  wifiConnected = result['Connected']})
+          }
+          Component.onCompleted: getProperties();
+
+          onWifiConnectedChanged: {
+              console.debug("wifistate is now",wifiConnected)
+          }
+      }
+
+    function checkConnection(ignoreConnection){
+        var cellularAllowed = configCellularDownloadsEnabled.value === true || ignoreConnection === true;
+        console.debug("Connection check: cellular allowed:",cellularAllowed," wifi connected: ", connmanWifi.wifiConnected)
+        return cellularAllowed || connmanWifi.wifiConnected;
+    }
+
+
+    function downloadBlockedDialog(callback){
+        console.info("suppressing playback, because not on wifi!");
+        pageStack.push(Qt.resolvedUrl("../ConnectionBlockedDialog.qml"),{"callback":callback})
+    }
+
+    function executeIfConnectionAllowed(callback){
+        if(checkConnection())
+            callback()
+        else
+            downloadBlockedDialog(callback)
+    }
+
+}

--- a/translations/harbour-org.gpodder.sailfish-bg.ts
+++ b/translations/harbour-org.gpodder.sailfish-bg.ts
@@ -97,42 +97,42 @@
 <context>
     <name>EpisodeItem</name>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Pause</source>
         <translation>Паузиране</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Play</source>
         <translation>Пускане</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="82"/>
+        <location filename="../qml/EpisodeItem.qml" line="92"/>
         <source>Download</source>
         <translation>Изтегляне</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="92"/>
+        <location filename="../qml/EpisodeItem.qml" line="102"/>
         <source>Enqueue</source>
         <translation>Към опашката</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="105"/>
+        <location filename="../qml/EpisodeItem.qml" line="115"/>
         <source>Delete</source>
         <translation>Изтриване</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <location filename="../qml/EpisodeItem.qml" line="121"/>
         <source>Deleting</source>
         <translation>Изтрива се</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="119"/>
+        <location filename="../qml/EpisodeItem.qml" line="129"/>
         <source>Toggle New</source>
         <translation>Като нов</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="125"/>
+        <location filename="../qml/EpisodeItem.qml" line="135"/>
         <source>Shownotes</source>
         <translation>Описание</translation>
     </message>
@@ -512,34 +512,39 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="55"/>
         <source>About</source>
         <translation>Относно</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="69"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>API Key (v3)</source>
         <translation>API ключ (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="84"/>
         <source>Limits</source>
         <translation>Ограничения</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="90"/>
         <source>Maximum episodes per feed</source>
         <translation>Максимален брой епизоди за RSS емисия</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
+        <source>Allow Downloads via mobile data</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-de.ts
+++ b/translations/harbour-org.gpodder.sailfish-de.ts
@@ -97,42 +97,42 @@
 <context>
     <name>EpisodeItem</name>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Pause</source>
         <translation type="unfinished">Pause</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Play</source>
         <translation type="unfinished">Abspielen</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="82"/>
+        <location filename="../qml/EpisodeItem.qml" line="92"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="92"/>
+        <location filename="../qml/EpisodeItem.qml" line="102"/>
         <source>Enqueue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="105"/>
+        <location filename="../qml/EpisodeItem.qml" line="115"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <location filename="../qml/EpisodeItem.qml" line="121"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="119"/>
+        <location filename="../qml/EpisodeItem.qml" line="129"/>
         <source>Toggle New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="125"/>
+        <location filename="../qml/EpisodeItem.qml" line="135"/>
         <source>Shownotes</source>
         <translation type="unfinished">Shownotes</translation>
     </message>
@@ -512,34 +512,39 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="55"/>
         <source>About</source>
         <translation>Über</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="69"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>API Key (v3)</source>
         <translation>API Schlüssel (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="84"/>
         <source>Limits</source>
         <translation>Grenzen</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="90"/>
         <source>Maximum episodes per feed</source>
         <translation>Maximale Anzahl Episoden pro Feed</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
+        <source>Allow Downloads via mobile data</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-es.ts
+++ b/translations/harbour-org.gpodder.sailfish-es.ts
@@ -97,42 +97,42 @@
 <context>
     <name>EpisodeItem</name>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Pause</source>
         <translation>Pausar</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Play</source>
         <translation>Reproducir</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="82"/>
+        <location filename="../qml/EpisodeItem.qml" line="92"/>
         <source>Download</source>
         <translation>Descargar</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="92"/>
+        <location filename="../qml/EpisodeItem.qml" line="102"/>
         <source>Enqueue</source>
         <translation>En cola</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="105"/>
+        <location filename="../qml/EpisodeItem.qml" line="115"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <location filename="../qml/EpisodeItem.qml" line="121"/>
         <source>Deleting</source>
         <translation>Borrando</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="119"/>
+        <location filename="../qml/EpisodeItem.qml" line="129"/>
         <source>Toggle New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="125"/>
+        <location filename="../qml/EpisodeItem.qml" line="135"/>
         <source>Shownotes</source>
         <translation>Notas</translation>
     </message>
@@ -512,34 +512,39 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="55"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="69"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>API Key (v3)</source>
         <translation>Clave API (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="84"/>
         <source>Limits</source>
         <translation>Límites</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="90"/>
         <source>Maximum episodes per feed</source>
         <translation>Núm. máximo de episodios por canal</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
+        <source>Allow Downloads via mobile data</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-it.ts
+++ b/translations/harbour-org.gpodder.sailfish-it.ts
@@ -97,42 +97,42 @@
 <context>
     <name>EpisodeItem</name>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Pause</source>
         <translation type="unfinished">Pausa</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Play</source>
         <translation type="unfinished">Riproduci</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="82"/>
+        <location filename="../qml/EpisodeItem.qml" line="92"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="92"/>
+        <location filename="../qml/EpisodeItem.qml" line="102"/>
         <source>Enqueue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="105"/>
+        <location filename="../qml/EpisodeItem.qml" line="115"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <location filename="../qml/EpisodeItem.qml" line="121"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="119"/>
+        <location filename="../qml/EpisodeItem.qml" line="129"/>
         <source>Toggle New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="125"/>
+        <location filename="../qml/EpisodeItem.qml" line="135"/>
         <source>Shownotes</source>
         <translation type="unfinished">Note</translation>
     </message>
@@ -512,34 +512,39 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="55"/>
         <source>About</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="69"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>API Key (v3)</source>
         <translation>API Key (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="84"/>
         <source>Limits</source>
         <translation>Limiti</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="90"/>
         <source>Maximum episodes per feed</source>
         <translation>Massimo episodi per feed</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
+        <source>Allow Downloads via mobile data</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-pl.ts
+++ b/translations/harbour-org.gpodder.sailfish-pl.ts
@@ -97,42 +97,42 @@
 <context>
     <name>EpisodeItem</name>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Pause</source>
         <translation>Pauza</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Play</source>
         <translation>Odtwarzaj</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="82"/>
+        <location filename="../qml/EpisodeItem.qml" line="92"/>
         <source>Download</source>
         <translation>Pobierz</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="92"/>
+        <location filename="../qml/EpisodeItem.qml" line="102"/>
         <source>Enqueue</source>
         <translation>Kolejkuj</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="105"/>
+        <location filename="../qml/EpisodeItem.qml" line="115"/>
         <source>Delete</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <location filename="../qml/EpisodeItem.qml" line="121"/>
         <source>Deleting</source>
         <translation>Usuwanie</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="119"/>
+        <location filename="../qml/EpisodeItem.qml" line="129"/>
         <source>Toggle New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="125"/>
+        <location filename="../qml/EpisodeItem.qml" line="135"/>
         <source>Shownotes</source>
         <translation type="unfinished">Opis odcinka</translation>
     </message>
@@ -512,34 +512,39 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="55"/>
         <source>About</source>
         <translation>O gPodder</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="69"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>API Key (v3)</source>
         <translation>Klucz API (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="84"/>
         <source>Limits</source>
         <translation>Limity</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="90"/>
         <source>Maximum episodes per feed</source>
         <translation>Maksymalna liczba odcinków na kanał</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
+        <source>Allow Downloads via mobile data</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-ru.ts
+++ b/translations/harbour-org.gpodder.sailfish-ru.ts
@@ -97,42 +97,42 @@
 <context>
     <name>EpisodeItem</name>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Pause</source>
         <translation>Пауза</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Play</source>
         <translation>Играть</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="82"/>
+        <location filename="../qml/EpisodeItem.qml" line="92"/>
         <source>Download</source>
         <translation>Скачать</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="92"/>
+        <location filename="../qml/EpisodeItem.qml" line="102"/>
         <source>Enqueue</source>
         <translation>В очередь</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="105"/>
+        <location filename="../qml/EpisodeItem.qml" line="115"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <location filename="../qml/EpisodeItem.qml" line="121"/>
         <source>Deleting</source>
         <translation>Удаление</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="119"/>
+        <location filename="../qml/EpisodeItem.qml" line="129"/>
         <source>Toggle New</source>
         <translation>Отмечать как новый</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="125"/>
+        <location filename="../qml/EpisodeItem.qml" line="135"/>
         <source>Shownotes</source>
         <translation>Описание</translation>
     </message>
@@ -512,34 +512,39 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="55"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>Settings</source>
         <translation>Настройка</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="69"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>API Key (v3)</source>
         <translation>Ключ API (версия 3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="84"/>
         <source>Limits</source>
         <translation>Ограничения</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="90"/>
         <source>Maximum episodes per feed</source>
         <translation>Максимальное число выпусков</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
+        <source>Allow Downloads via mobile data</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-sv.ts
+++ b/translations/harbour-org.gpodder.sailfish-sv.ts
@@ -97,42 +97,42 @@
 <context>
     <name>EpisodeItem</name>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Pause</source>
         <translation>Paus</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Play</source>
         <translation>Spela</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="82"/>
+        <location filename="../qml/EpisodeItem.qml" line="92"/>
         <source>Download</source>
         <translation>Ladda ner</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="92"/>
+        <location filename="../qml/EpisodeItem.qml" line="102"/>
         <source>Enqueue</source>
         <translation>Köa</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="105"/>
+        <location filename="../qml/EpisodeItem.qml" line="115"/>
         <source>Delete</source>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <location filename="../qml/EpisodeItem.qml" line="121"/>
         <source>Deleting</source>
         <translation>Tar bort</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="119"/>
+        <location filename="../qml/EpisodeItem.qml" line="129"/>
         <source>Toggle New</source>
         <translation>Ny av/på</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="125"/>
+        <location filename="../qml/EpisodeItem.qml" line="135"/>
         <source>Shownotes</source>
         <translation>Visa notiser</translation>
     </message>
@@ -512,34 +512,39 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="55"/>
         <source>About</source>
         <translation>Om</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="69"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>API Key (v3)</source>
         <translation>API-nyckel (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="84"/>
         <source>Limits</source>
         <translation>Begränsningar</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="90"/>
         <source>Maximum episodes per feed</source>
         <translation>Max antal avsnitt per flöde</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
+        <source>Allow Downloads via mobile data</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-zh_CN.ts
+++ b/translations/harbour-org.gpodder.sailfish-zh_CN.ts
@@ -97,42 +97,42 @@
 <context>
     <name>EpisodeItem</name>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Pause</source>
         <translation>暂停</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Play</source>
         <translation>播放</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="82"/>
+        <location filename="../qml/EpisodeItem.qml" line="92"/>
         <source>Download</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="92"/>
+        <location filename="../qml/EpisodeItem.qml" line="102"/>
         <source>Enqueue</source>
         <translation>队列</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="105"/>
+        <location filename="../qml/EpisodeItem.qml" line="115"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <location filename="../qml/EpisodeItem.qml" line="121"/>
         <source>Deleting</source>
         <translation>删除中</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="119"/>
+        <location filename="../qml/EpisodeItem.qml" line="129"/>
         <source>Toggle New</source>
         <translation>切到新的</translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="125"/>
+        <location filename="../qml/EpisodeItem.qml" line="135"/>
         <source>Shownotes</source>
         <translation>剧集说明</translation>
     </message>
@@ -512,34 +512,39 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="55"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="69"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>API Key (v3)</source>
         <translation>API 密钥(v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="84"/>
         <source>Limits</source>
         <translation>限制</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="90"/>
         <source>Maximum episodes per feed</source>
         <translation>每个订阅流的最大剧集</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
+        <source>Allow Downloads via mobile data</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish.ts
+++ b/translations/harbour-org.gpodder.sailfish.ts
@@ -97,42 +97,42 @@
 <context>
     <name>EpisodeItem</name>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="70"/>
+        <location filename="../qml/EpisodeItem.qml" line="72"/>
         <source>Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="82"/>
+        <location filename="../qml/EpisodeItem.qml" line="92"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="92"/>
+        <location filename="../qml/EpisodeItem.qml" line="102"/>
         <source>Enqueue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="105"/>
+        <location filename="../qml/EpisodeItem.qml" line="115"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="111"/>
+        <location filename="../qml/EpisodeItem.qml" line="121"/>
         <source>Deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="119"/>
+        <location filename="../qml/EpisodeItem.qml" line="129"/>
         <source>Toggle New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/EpisodeItem.qml" line="125"/>
+        <location filename="../qml/EpisodeItem.qml" line="135"/>
         <source>Shownotes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -512,33 +512,38 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="55"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="69"/>
         <source>YouTube</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>API Key (v3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="84"/>
         <source>Limits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="90"/>
         <source>Maximum episodes per feed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
+        <source>Allow Downloads via mobile data</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This is a WIP but I would like some feedback assistance.
Basic functionality is implemented. If the config option is set, pressing play/ or download on not downloaded items triggers a dialog which informs you that you are on mobile data and asks you if you want to procede anyway.

Now my request for ideas, assistance:
If on an EpisodeItem play is clicked while on mobile data (only then) I get the following error:

```
file:///usr/share/harbour-org.gpodder.sailfish/qml/EpisodeItem.qml:86: TypeError: Cannot call method 'playbackEpisode' of undefined
```
If I'm on wifi, the function gets executed directly, if i am not,  the dialog executes the callback. In the latter case the reference to id gets lost somewhere on the way.
I don't really understand why. Even with js fu like context changes depending on who is calling the method, player is still defined at root level...

SourceCode for reference:
https://github.com/thigg/gpodder-sailfish/blob/7bdccf603b31fb39d627b6b2c80e17fb1af36750/qml/EpisodeItem.qml#L76-L87
