### PR TITLE
fix: EpisodeItem menu download icon for SF4.5.0

### DIFF
--- a/qml/EpisodeItem.qml
+++ b/qml/EpisodeItem.qml
@@ -80,7 +80,7 @@ ListItem {
 
             GpodderIconMenuItem {
                 text: qsTr("Download")
-                icon.source: 'image://theme/icon-m-download'
+                icon.source: 'image://theme/icon-m-cloud-download'
                 visible: downloadState !== Constants.state.downloaded
                 onClicked: {
                     episodeItem.closeMenu();


### PR DESCRIPTION
Tested on my Xperia 10 II with SF4.5.0.16
I do not know what this will do on previous versions.