### PR TITLE
Changed Identity value to "gPodder"

### DIFF
--- a/qml/MprisPlayer.qml
+++ b/qml/MprisPlayer.qml
@@ -26,7 +26,7 @@ MprisPlayer {
 
 
     // Mpris2 Root Interface
-    identity: "Mpris gpodder-sailfish"
+    identity: "gPodder"
 
     // Mpris2 Player Interface
     canControl: true


### PR DESCRIPTION
The identity is now visible as a detail on the mpris lock screen controls, since SailfishOS 4.5. It makes sense to have a nontechnical value but the name of the app.