### PR TITLE
Configurable speed

### DIFF
--- a/qml/PlayerPage.qml
+++ b/qml/PlayerPage.qml
@@ -30,6 +30,19 @@ Page {
 
     allowedOrientations: Orientation.All
 
+    onStatusChanged: {
+        if (status === PageStatus.Activating) {
+            py.getConfig('ui.qml.playback_speed.stepSize', function (value) {
+                speedSlider.stepSize = value;
+            });
+            py.getConfig('ui.qml.playback_speed.minimumValue', function (value) {
+                speedSlider.minimumValue = value;
+            });
+            py.getConfig('ui.qml.playback_speed.maximumValue', function (value) {
+                speedSlider.maximumValue = value;
+            });
+        }
+    }
     SilicaFlickable {
         id: flickable
         anchors.fill: parent
@@ -120,6 +133,8 @@ Page {
                     asynchronous: true
 
                     source: player.episode_art !== '' ? player.episode_art : player.cover_art
+
+                    onStateChanged: console.log("source: " + source)
                 }
             }
             Column {
@@ -346,9 +361,6 @@ Page {
 
                                 value: player.playbackRate
                                 valueText: Math.round(value * 100) / 100
-                                minimumValue: 0.5
-                                maximumValue: 3.0
-                                stepSize: 0.25
                                 onDownChanged: {
                                     if (!down) {
                                         player.playbackRate = sliderValue

--- a/qml/SettingsPage.qml
+++ b/qml/SettingsPage.qml
@@ -35,9 +35,21 @@ Page {
             py.getConfig('limit.episodes', function (value) {
                 limit_episodes.value = value;
             });
+            py.getConfig('ui.qml.playback_speed.stepSize', function (value) {
+                speed_increment.value = value;
+            });
+            py.getConfig('ui.qml.playback_speed.minimumValue', function (value) {
+                speed_min.text = value;
+            });
+            py.getConfig('ui.qml.playback_speed.maximumValue', function (value) {
+                speed_max.text = value;
+            });
         } else if (status === PageStatus.Deactivating) {
             py.setConfig('plugins.youtube.api_key_v3', youtube_api_key_v3.text);
             py.setConfig('limit.episodes', parseInt(limit_episodes.value));
+            py.setConfig('ui.qml.playback_speed.stepSize', parseFloat(speed_increment.value));
+            py.setConfig('ui.qml.playback_speed.minimumValue', parseFloat(speed_min.text));
+            py.setConfig('ui.qml.playback_speed.maximumValue', parseFloat(speed_max.text));
             youtube_api_key_v3.focus = false;
         }
     }
@@ -91,6 +103,48 @@ Page {
                 minimumValue: 100
                 maximumValue: 1000
                 stepSize: 100
+            }
+
+            Slider {
+                id: speed_increment
+                label: qsTr("Speed increments")
+                valueText: value
+                width: parent.width
+                minimumValue: speed_increment.stepSize
+                maximumValue: 1.00
+                stepSize: 0.05
+            }
+
+            TextField {
+                id: speed_min
+                label: qsTr("Playback speed - lower limit")
+                placeholderText: label
+                width: parent.width
+                inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhFormattedNumbersOnly
+                EnterKey.iconSource: (text.length > 0) ? "image://theme/icon-m-enter-accept" : "image://theme/icon-m-enter-close"
+                EnterKey.onClicked: focus = false
+                validator: DoubleValidator {
+                    bottom: speed_increment.value
+                    decimals: 2
+                    notation: DoubleValidator.StandardNotation
+                    top: parseFloat(speed_max.text) - speed_increment.stepSize
+                }
+            }
+
+            TextField {
+                id: speed_max
+                label: qsTr("Playback speed - upper limit")
+                placeholderText: label
+                width: parent.width
+                inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhFormattedNumbersOnly
+                EnterKey.iconSource: (text.length > 0) ? "image://theme/icon-m-enter-accept" : "image://theme/icon-m-enter-close"
+                EnterKey.onClicked: focus = false
+                validator: DoubleValidator {
+                    bottom: parseFloat(speed_min.text) + speed_increment.stepSize
+                    decimals: 2
+                    notation: DoubleValidator.StandardNotation
+                    top: 5
+                }
             }
         }
     }

--- a/translations/harbour-org.gpodder.sailfish-bg.ts
+++ b/translations/harbour-org.gpodder.sailfish-bg.ts
@@ -275,72 +275,72 @@
 <context>
     <name>PlayerPage</name>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Stop sleep timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Sleep timer</source>
         <translation type="unfinished">Отброяване до заспиване</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="57"/>
+        <location filename="../qml/PlayerPage.qml" line="70"/>
         <source>Clear play queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="131"/>
+        <location filename="../qml/PlayerPage.qml" line="146"/>
         <source>Now playing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="220"/>
+        <location filename="../qml/PlayerPage.qml" line="235"/>
         <source>Sleep timer: </source>
         <translation type="unfinished">Отброяване до заспиване: </translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="259"/>
+        <location filename="../qml/PlayerPage.qml" line="274"/>
         <source>- 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="269"/>
+        <location filename="../qml/PlayerPage.qml" line="284"/>
         <source>- 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Pause</source>
         <translation type="unfinished">Паузиране</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Play</source>
         <translation type="unfinished">Пускане</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="290"/>
+        <location filename="../qml/PlayerPage.qml" line="305"/>
         <source>+ 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="299"/>
+        <location filename="../qml/PlayerPage.qml" line="314"/>
         <source>+ 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="311"/>
+        <location filename="../qml/PlayerPage.qml" line="326"/>
         <source>Playback speed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="363"/>
+        <location filename="../qml/PlayerPage.qml" line="375"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="387"/>
+        <location filename="../qml/PlayerPage.qml" line="399"/>
         <source>Remove from queue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -508,34 +508,49 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>About</source>
         <translation>Относно</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="79"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="85"/>
         <source>API Key (v3)</source>
         <translation>API ключ (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="94"/>
         <source>Limits</source>
         <translation>Ограничения</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
         <source>Maximum episodes per feed</source>
         <translation>Максимален брой епизоди за RSS емисия</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="110"/>
+        <source>Speed increments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="120"/>
+        <source>Playback speed - lower limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="136"/>
+        <source>Playback speed - upper limit</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-de.ts
+++ b/translations/harbour-org.gpodder.sailfish-de.ts
@@ -274,72 +274,72 @@
 <context>
     <name>PlayerPage</name>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Stop sleep timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Sleep timer</source>
         <translation type="unfinished">Sleeptimer</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="57"/>
+        <location filename="../qml/PlayerPage.qml" line="70"/>
         <source>Clear play queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="131"/>
+        <location filename="../qml/PlayerPage.qml" line="146"/>
         <source>Now playing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="220"/>
+        <location filename="../qml/PlayerPage.qml" line="235"/>
         <source>Sleep timer: </source>
         <translation type="unfinished">Sleep Timer: </translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="259"/>
+        <location filename="../qml/PlayerPage.qml" line="274"/>
         <source>- 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="269"/>
+        <location filename="../qml/PlayerPage.qml" line="284"/>
         <source>- 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Pause</source>
         <translation type="unfinished">Pause</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Play</source>
         <translation type="unfinished">Abspielen</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="290"/>
+        <location filename="../qml/PlayerPage.qml" line="305"/>
         <source>+ 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="299"/>
+        <location filename="../qml/PlayerPage.qml" line="314"/>
         <source>+ 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="311"/>
+        <location filename="../qml/PlayerPage.qml" line="326"/>
         <source>Playback speed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="363"/>
+        <location filename="../qml/PlayerPage.qml" line="375"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="387"/>
+        <location filename="../qml/PlayerPage.qml" line="399"/>
         <source>Remove from queue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,34 +507,49 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>About</source>
         <translation>Über</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="79"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="85"/>
         <source>API Key (v3)</source>
         <translation>API Schlüssel (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="94"/>
         <source>Limits</source>
         <translation>Grenzen</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
         <source>Maximum episodes per feed</source>
         <translation>Maximale Anzahl Episoden pro Feed</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="110"/>
+        <source>Speed increments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="120"/>
+        <source>Playback speed - lower limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="136"/>
+        <source>Playback speed - upper limit</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-es.ts
+++ b/translations/harbour-org.gpodder.sailfish-es.ts
@@ -274,72 +274,72 @@
 <context>
     <name>PlayerPage</name>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Stop sleep timer</source>
         <translation>Detener temporizador</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Sleep timer</source>
         <translation>Temporizador</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="57"/>
+        <location filename="../qml/PlayerPage.qml" line="70"/>
         <source>Clear play queue</source>
         <translation>Borrar cola</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="131"/>
+        <location filename="../qml/PlayerPage.qml" line="146"/>
         <source>Now playing</source>
         <translation>Reproduciendo</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="220"/>
+        <location filename="../qml/PlayerPage.qml" line="235"/>
         <source>Sleep timer: </source>
         <translation>Temporizador: </translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="259"/>
+        <location filename="../qml/PlayerPage.qml" line="274"/>
         <source>- 1 min</source>
         <translation>- 1 min</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="269"/>
+        <location filename="../qml/PlayerPage.qml" line="284"/>
         <source>- 10 sec</source>
         <translation>- 10 seg</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Pause</source>
         <translation>Pausar</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Play</source>
         <translation>Reproducir</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="290"/>
+        <location filename="../qml/PlayerPage.qml" line="305"/>
         <source>+ 10 sec</source>
         <translation>+ 10 seg</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="299"/>
+        <location filename="../qml/PlayerPage.qml" line="314"/>
         <source>+ 1 min</source>
         <translation>+ 1 min</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="311"/>
+        <location filename="../qml/PlayerPage.qml" line="326"/>
         <source>Playback speed: </source>
         <translation>Velocidad: </translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="363"/>
+        <location filename="../qml/PlayerPage.qml" line="375"/>
         <source>Queue</source>
         <translation>Cola</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="387"/>
+        <location filename="../qml/PlayerPage.qml" line="399"/>
         <source>Remove from queue</source>
         <translation>Quitar de la cola</translation>
     </message>
@@ -507,34 +507,49 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="79"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="85"/>
         <source>API Key (v3)</source>
         <translation>Clave API (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="94"/>
         <source>Limits</source>
         <translation>Límites</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
         <source>Maximum episodes per feed</source>
         <translation>Núm. máximo de episodios por canal</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="110"/>
+        <source>Speed increments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="120"/>
+        <source>Playback speed - lower limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="136"/>
+        <source>Playback speed - upper limit</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-it.ts
+++ b/translations/harbour-org.gpodder.sailfish-it.ts
@@ -274,72 +274,72 @@
 <context>
     <name>PlayerPage</name>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Stop sleep timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Sleep timer</source>
         <translation type="unfinished">Timer spegnimento</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="57"/>
+        <location filename="../qml/PlayerPage.qml" line="70"/>
         <source>Clear play queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="131"/>
+        <location filename="../qml/PlayerPage.qml" line="146"/>
         <source>Now playing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="220"/>
+        <location filename="../qml/PlayerPage.qml" line="235"/>
         <source>Sleep timer: </source>
         <translation type="unfinished">Timer spegnimento: </translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="259"/>
+        <location filename="../qml/PlayerPage.qml" line="274"/>
         <source>- 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="269"/>
+        <location filename="../qml/PlayerPage.qml" line="284"/>
         <source>- 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Pause</source>
         <translation type="unfinished">Pausa</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Play</source>
         <translation type="unfinished">Riproduci</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="290"/>
+        <location filename="../qml/PlayerPage.qml" line="305"/>
         <source>+ 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="299"/>
+        <location filename="../qml/PlayerPage.qml" line="314"/>
         <source>+ 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="311"/>
+        <location filename="../qml/PlayerPage.qml" line="326"/>
         <source>Playback speed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="363"/>
+        <location filename="../qml/PlayerPage.qml" line="375"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="387"/>
+        <location filename="../qml/PlayerPage.qml" line="399"/>
         <source>Remove from queue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,34 +507,49 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>About</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="79"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="85"/>
         <source>API Key (v3)</source>
         <translation>API Key (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="94"/>
         <source>Limits</source>
         <translation>Limiti</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
         <source>Maximum episodes per feed</source>
         <translation>Massimo episodi per feed</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="110"/>
+        <source>Speed increments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="120"/>
+        <source>Playback speed - lower limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="136"/>
+        <source>Playback speed - upper limit</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-pl.ts
+++ b/translations/harbour-org.gpodder.sailfish-pl.ts
@@ -274,72 +274,72 @@
 <context>
     <name>PlayerPage</name>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Stop sleep timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Sleep timer</source>
         <translation type="unfinished">Wyłącznik czasowy</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="57"/>
+        <location filename="../qml/PlayerPage.qml" line="70"/>
         <source>Clear play queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="131"/>
+        <location filename="../qml/PlayerPage.qml" line="146"/>
         <source>Now playing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="220"/>
+        <location filename="../qml/PlayerPage.qml" line="235"/>
         <source>Sleep timer: </source>
         <translation type="unfinished">Wyłącznik czasowy: </translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="259"/>
+        <location filename="../qml/PlayerPage.qml" line="274"/>
         <source>- 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="269"/>
+        <location filename="../qml/PlayerPage.qml" line="284"/>
         <source>- 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Pause</source>
         <translation type="unfinished">Pauza</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Play</source>
         <translation type="unfinished">Odtwarzaj</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="290"/>
+        <location filename="../qml/PlayerPage.qml" line="305"/>
         <source>+ 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="299"/>
+        <location filename="../qml/PlayerPage.qml" line="314"/>
         <source>+ 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="311"/>
+        <location filename="../qml/PlayerPage.qml" line="326"/>
         <source>Playback speed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="363"/>
+        <location filename="../qml/PlayerPage.qml" line="375"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="387"/>
+        <location filename="../qml/PlayerPage.qml" line="399"/>
         <source>Remove from queue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,34 +507,49 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>About</source>
         <translation>O gPodder</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="79"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="85"/>
         <source>API Key (v3)</source>
         <translation>Klucz API (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="94"/>
         <source>Limits</source>
         <translation>Limity</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
         <source>Maximum episodes per feed</source>
         <translation>Maksymalna liczba odcinków na kanał</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="110"/>
+        <source>Speed increments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="120"/>
+        <source>Playback speed - lower limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="136"/>
+        <source>Playback speed - upper limit</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-ru.ts
+++ b/translations/harbour-org.gpodder.sailfish-ru.ts
@@ -274,72 +274,72 @@
 <context>
     <name>PlayerPage</name>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Stop sleep timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Sleep timer</source>
         <translation type="unfinished">Отключиться через</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="57"/>
+        <location filename="../qml/PlayerPage.qml" line="70"/>
         <source>Clear play queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="131"/>
+        <location filename="../qml/PlayerPage.qml" line="146"/>
         <source>Now playing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="220"/>
+        <location filename="../qml/PlayerPage.qml" line="235"/>
         <source>Sleep timer: </source>
         <translation type="unfinished">Таймер сна: </translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="259"/>
+        <location filename="../qml/PlayerPage.qml" line="274"/>
         <source>- 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="269"/>
+        <location filename="../qml/PlayerPage.qml" line="284"/>
         <source>- 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Pause</source>
         <translation type="unfinished">Пауза</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Play</source>
         <translation type="unfinished">Играть</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="290"/>
+        <location filename="../qml/PlayerPage.qml" line="305"/>
         <source>+ 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="299"/>
+        <location filename="../qml/PlayerPage.qml" line="314"/>
         <source>+ 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="311"/>
+        <location filename="../qml/PlayerPage.qml" line="326"/>
         <source>Playback speed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="363"/>
+        <location filename="../qml/PlayerPage.qml" line="375"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="387"/>
+        <location filename="../qml/PlayerPage.qml" line="399"/>
         <source>Remove from queue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,34 +507,49 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>Settings</source>
         <translation>Настройка</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="79"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="85"/>
         <source>API Key (v3)</source>
         <translation>Ключ API (версия 3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="94"/>
         <source>Limits</source>
         <translation>Ограничения</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
         <source>Maximum episodes per feed</source>
         <translation>Максимальное число выпусков</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="110"/>
+        <source>Speed increments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="120"/>
+        <source>Playback speed - lower limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="136"/>
+        <source>Playback speed - upper limit</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-sv.ts
+++ b/translations/harbour-org.gpodder.sailfish-sv.ts
@@ -274,72 +274,72 @@
 <context>
     <name>PlayerPage</name>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Stop sleep timer</source>
         <translation>Stopp tiduret</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Sleep timer</source>
         <translation>Insomningstidur</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="57"/>
+        <location filename="../qml/PlayerPage.qml" line="70"/>
         <source>Clear play queue</source>
         <translation>Rensa spelningskön</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="131"/>
+        <location filename="../qml/PlayerPage.qml" line="146"/>
         <source>Now playing</source>
         <translation>Nu spelas</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="220"/>
+        <location filename="../qml/PlayerPage.qml" line="235"/>
         <source>Sleep timer: </source>
         <translation>Insomningstidur: </translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="259"/>
+        <location filename="../qml/PlayerPage.qml" line="274"/>
         <source>- 1 min</source>
         <translation>- 1 min</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="269"/>
+        <location filename="../qml/PlayerPage.qml" line="284"/>
         <source>- 10 sec</source>
         <translation>- 10 sek</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Pause</source>
         <translation>Paus</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Play</source>
         <translation>Spela</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="290"/>
+        <location filename="../qml/PlayerPage.qml" line="305"/>
         <source>+ 10 sec</source>
         <translation>+ 10 sek</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="299"/>
+        <location filename="../qml/PlayerPage.qml" line="314"/>
         <source>+ 1 min</source>
         <translation>+ 1 min</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="311"/>
+        <location filename="../qml/PlayerPage.qml" line="326"/>
         <source>Playback speed: </source>
         <translation>Uppspelningshastighet: </translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="363"/>
+        <location filename="../qml/PlayerPage.qml" line="375"/>
         <source>Queue</source>
         <translation>Köa</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="387"/>
+        <location filename="../qml/PlayerPage.qml" line="399"/>
         <source>Remove from queue</source>
         <translation>Ta bort från kön</translation>
     </message>
@@ -507,34 +507,49 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>About</source>
         <translation>Om</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="79"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="85"/>
         <source>API Key (v3)</source>
         <translation>API-nyckel (v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="94"/>
         <source>Limits</source>
         <translation>Begränsningar</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
         <source>Maximum episodes per feed</source>
         <translation>Max antal avsnitt per flöde</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="110"/>
+        <source>Speed increments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="120"/>
+        <source>Playback speed - lower limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="136"/>
+        <source>Playback speed - upper limit</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish-zh_CN.ts
+++ b/translations/harbour-org.gpodder.sailfish-zh_CN.ts
@@ -274,72 +274,72 @@
 <context>
     <name>PlayerPage</name>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Stop sleep timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Sleep timer</source>
         <translation type="unfinished">睡眠计时器</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="57"/>
+        <location filename="../qml/PlayerPage.qml" line="70"/>
         <source>Clear play queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="131"/>
+        <location filename="../qml/PlayerPage.qml" line="146"/>
         <source>Now playing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="220"/>
+        <location filename="../qml/PlayerPage.qml" line="235"/>
         <source>Sleep timer: </source>
         <translation type="unfinished">睡眠计时器：</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="259"/>
+        <location filename="../qml/PlayerPage.qml" line="274"/>
         <source>- 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="269"/>
+        <location filename="../qml/PlayerPage.qml" line="284"/>
         <source>- 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Pause</source>
         <translation type="unfinished">暂停</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Play</source>
         <translation type="unfinished">播放</translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="290"/>
+        <location filename="../qml/PlayerPage.qml" line="305"/>
         <source>+ 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="299"/>
+        <location filename="../qml/PlayerPage.qml" line="314"/>
         <source>+ 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="311"/>
+        <location filename="../qml/PlayerPage.qml" line="326"/>
         <source>Playback speed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="363"/>
+        <location filename="../qml/PlayerPage.qml" line="375"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="387"/>
+        <location filename="../qml/PlayerPage.qml" line="399"/>
         <source>Remove from queue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,34 +507,49 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="79"/>
         <source>YouTube</source>
         <translation>YouTube</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="85"/>
         <source>API Key (v3)</source>
         <translation>API 密钥(v3)</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="94"/>
         <source>Limits</source>
         <translation>限制</translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
         <source>Maximum episodes per feed</source>
         <translation>每个订阅流的最大剧集</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="110"/>
+        <source>Speed increments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="120"/>
+        <source>Playback speed - lower limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="136"/>
+        <source>Playback speed - upper limit</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-org.gpodder.sailfish.ts
+++ b/translations/harbour-org.gpodder.sailfish.ts
@@ -274,72 +274,72 @@
 <context>
     <name>PlayerPage</name>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Stop sleep timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="46"/>
+        <location filename="../qml/PlayerPage.qml" line="59"/>
         <source>Sleep timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="57"/>
+        <location filename="../qml/PlayerPage.qml" line="70"/>
         <source>Clear play queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="131"/>
+        <location filename="../qml/PlayerPage.qml" line="146"/>
         <source>Now playing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="220"/>
+        <location filename="../qml/PlayerPage.qml" line="235"/>
         <source>Sleep timer: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="259"/>
+        <location filename="../qml/PlayerPage.qml" line="274"/>
         <source>- 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="269"/>
+        <location filename="../qml/PlayerPage.qml" line="284"/>
         <source>- 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="278"/>
+        <location filename="../qml/PlayerPage.qml" line="293"/>
         <source>Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="290"/>
+        <location filename="../qml/PlayerPage.qml" line="305"/>
         <source>+ 10 sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="299"/>
+        <location filename="../qml/PlayerPage.qml" line="314"/>
         <source>+ 1 min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="311"/>
+        <location filename="../qml/PlayerPage.qml" line="326"/>
         <source>Playback speed: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="363"/>
+        <location filename="../qml/PlayerPage.qml" line="375"/>
         <source>Queue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/PlayerPage.qml" line="387"/>
+        <location filename="../qml/PlayerPage.qml" line="399"/>
         <source>Remove from queue</source>
         <translation type="unfinished"></translation>
     </message>
@@ -507,33 +507,48 @@
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="53"/>
+        <location filename="../qml/SettingsPage.qml" line="65"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="63"/>
+        <location filename="../qml/SettingsPage.qml" line="75"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="67"/>
+        <location filename="../qml/SettingsPage.qml" line="79"/>
         <source>YouTube</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="73"/>
+        <location filename="../qml/SettingsPage.qml" line="85"/>
         <source>API Key (v3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="82"/>
+        <location filename="../qml/SettingsPage.qml" line="94"/>
         <source>Limits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/SettingsPage.qml" line="88"/>
+        <location filename="../qml/SettingsPage.qml" line="100"/>
         <source>Maximum episodes per feed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="110"/>
+        <source>Speed increments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="120"/>
+        <source>Playback speed - lower limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsPage.qml" line="136"/>
+        <source>Playback speed - upper limit</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The update of gpodder-core adds 2 things:
1. Settings for the speed slider in the player
2. The gpodder.net plugin is disabled

And this also adds the UI changers on the gpodder-sailfish side to support using settings for the speed slider in the player.