### PR TITLE
Support more HTML in descriptions.

### DIFF
--- a/qml/EpisodeDetail.qml
+++ b/qml/EpisodeDetail.qml
@@ -203,7 +203,7 @@ Page {
             }
 
             Label {
-                textFormat: Text.StyledText
+                textFormat: Text.RichText
                 text: detailPage.description
                 linkColor: Theme.highlightColor
                 anchors {


### PR DESCRIPTION
Fixes #58

*Background*
- The podcast has both plaintext and html descriptions.
- The html description will get priority over plaintext but html uses &ouml; instead of \xf6
- `Text.StyledText` is HTML 3.2 which does not support it
- `Text.RichText` is HTML 4 which does support it.

From basic sanity checks this does not seem to impact plaintext descriptions negatively.