### PR TITLE
Fix notification event for add podcast

### DIFF
--- a/common/main.py
+++ b/common/main.py
@@ -266,7 +266,7 @@ class gPotherSide:
         try:
             podcast = self.core.model.load_podcast(url, create=True)
         except Exception as e:
-            pyotherside.send('core-error', 'Podcast: {}\nFeed URL: {}\nload_podcast error: {}'.format(podcast.title, podcast.url, str(e)))
+            pyotherside.send('core-error', 'Feed URL: {}\nload_podcast error: {}'.format(url, str(e)))
             pyotherside.send('podcast-list-changed')
             return false
 


### PR DESCRIPTION
Fixing error introduced when I copied the more verbose error message from podast updates.

Here podcast is not defined in most cases since an exception happened while it was being initialized, thus generating the error string failed.