### PR TITLE
Loading feedback

### DIFF
--- a/common/GPodderCore.qml
+++ b/common/GPodderCore.qml
@@ -43,7 +43,7 @@ Python {
     signal updateStats()
     signal configChanged(string key, var value)
     signal coreError(string message)
-    signal loadingText(string message)
+    signal loadingText(string message_id)
 
     Component.onCompleted: {
         setHandler('hello', function (coreversion, uiversion, parserversion) {

--- a/common/GPodderCore.qml
+++ b/common/GPodderCore.qml
@@ -43,6 +43,7 @@ Python {
     signal updateStats()
     signal configChanged(string key, var value)
     signal coreError(string message)
+    signal loadingText(string message)
 
     Component.onCompleted: {
         setHandler('hello', function (coreversion, uiversion, parserversion) {
@@ -68,6 +69,7 @@ Python {
         setHandler('update-stats', py.updateStats);
         setHandler('config-changed', py.configChanged);
         setHandler('core-error', py.coreError);
+        setHandler('loading-text', py.loadingText);
 
         addImportPath(Qt.resolvedUrl('../..'));
 

--- a/common/GPodderCore.qml
+++ b/common/GPodderCore.qml
@@ -52,7 +52,7 @@ Python {
             py.parserversion = parserversion;
 
             console.log('gPodder Core ' + py.coreversion);
-            console.log('gPodder QML UI ' + py.uiversion);
+            console.log('gPodder Sailfish ' + py.uiversion);
             console.log('Podcastparser ' + py.parserversion);
             console.log('PyOtherSide ' + py.pluginVersion());
             console.log('Python ' + py.pythonVersion());

--- a/common/main.py
+++ b/common/main.py
@@ -69,7 +69,9 @@ class gPotherSide:
     def initialize(self, progname):
         assert self.core is None, 'Already initialized'
 
+        pyotherside.send('loading-text', 'Initializing Core')
         self.core = core.Core(progname=progname)
+        pyotherside.send('loading-text', 'Loading Podcasts')
         pyotherside.send('podcast-list-changed')
 
         self.core.config.add_observer(self._config_option_changed)

--- a/common/main.py
+++ b/common/main.py
@@ -69,9 +69,9 @@ class gPotherSide:
     def initialize(self, progname):
         assert self.core is None, 'Already initialized'
 
-        pyotherside.send('loading-text', 'Initializing Core')
+        pyotherside.send('loading-text', 'initializing-core')
         self.core = core.Core(progname=progname)
-        pyotherside.send('loading-text', 'Loading Podcasts')
+        pyotherside.send('loading-text', 'loading-podcasts')
         pyotherside.send('podcast-list-changed')
 
         self.core.config.add_observer(self._config_option_changed)

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -97,7 +97,21 @@ PodcastsPage {
     BusyIndicator {
         size: BusyIndicatorSize.Large
         anchors.centerIn: parent
-        visible: !py.ready
+        visible: !podcastListModel.firstRun
         running: visible
+        Label {
+            id: loadingIndicatorText
+            anchors.top: parent.bottom
+            anchors.horizontalCenter: parent.horizontalCenter
+            horizontalAlignment: Text.AlignHCenter
+            text: 'gPodder ' + py.uiversion
+
+            Connections {
+                target: py
+                onLoadingText: {
+                    loadingIndicatorText.text += "\n" + message
+                }
+            }
+        }
     }
 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -109,7 +109,13 @@ PodcastsPage {
             Connections {
                 target: py
                 onLoadingText: {
-                    loadingIndicatorText.text += "\n" + message
+                    if (message_id === 'initializing-core') {
+                        loadingIndicatorText.text += '\n' + qsTr('Initializing Core');
+                    } else if (message_id === 'loading-podcasts') {
+                        loadingIndicatorText.text += '\n' + qsTr('Loading Podcasts');
+                    } else {
+                        loadingIndicatorText.text += '\n' + message_id;
+                    }
                 }
             }
         }

--- a/translations/harbour-org.gpodder.sailfish-bg.ts
+++ b/translations/harbour-org.gpodder.sailfish-bg.ts
@@ -257,6 +257,19 @@
     </message>
 </context>
 <context>
+    <name>Main</name>
+    <message>
+        <location filename="../qml/Main.qml" line="113"/>
+        <source>Initializing Core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Main.qml" line="115"/>
+        <source>Loading Podcasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerChaptersDialog</name>
     <message>
         <location filename="../qml/PlayerChaptersDialog.qml" line="37"/>

--- a/translations/harbour-org.gpodder.sailfish-de.ts
+++ b/translations/harbour-org.gpodder.sailfish-de.ts
@@ -256,6 +256,19 @@
     </message>
 </context>
 <context>
+    <name>Main</name>
+    <message>
+        <location filename="../qml/Main.qml" line="113"/>
+        <source>Initializing Core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Main.qml" line="115"/>
+        <source>Loading Podcasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerChaptersDialog</name>
     <message>
         <location filename="../qml/PlayerChaptersDialog.qml" line="37"/>

--- a/translations/harbour-org.gpodder.sailfish-es.ts
+++ b/translations/harbour-org.gpodder.sailfish-es.ts
@@ -256,6 +256,19 @@
     </message>
 </context>
 <context>
+    <name>Main</name>
+    <message>
+        <location filename="../qml/Main.qml" line="113"/>
+        <source>Initializing Core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Main.qml" line="115"/>
+        <source>Loading Podcasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerChaptersDialog</name>
     <message>
         <location filename="../qml/PlayerChaptersDialog.qml" line="37"/>

--- a/translations/harbour-org.gpodder.sailfish-it.ts
+++ b/translations/harbour-org.gpodder.sailfish-it.ts
@@ -256,6 +256,19 @@
     </message>
 </context>
 <context>
+    <name>Main</name>
+    <message>
+        <location filename="../qml/Main.qml" line="113"/>
+        <source>Initializing Core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Main.qml" line="115"/>
+        <source>Loading Podcasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerChaptersDialog</name>
     <message>
         <location filename="../qml/PlayerChaptersDialog.qml" line="37"/>

--- a/translations/harbour-org.gpodder.sailfish-pl.ts
+++ b/translations/harbour-org.gpodder.sailfish-pl.ts
@@ -256,6 +256,19 @@
     </message>
 </context>
 <context>
+    <name>Main</name>
+    <message>
+        <location filename="../qml/Main.qml" line="113"/>
+        <source>Initializing Core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Main.qml" line="115"/>
+        <source>Loading Podcasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerChaptersDialog</name>
     <message>
         <location filename="../qml/PlayerChaptersDialog.qml" line="37"/>

--- a/translations/harbour-org.gpodder.sailfish-ru.ts
+++ b/translations/harbour-org.gpodder.sailfish-ru.ts
@@ -256,6 +256,19 @@
     </message>
 </context>
 <context>
+    <name>Main</name>
+    <message>
+        <location filename="../qml/Main.qml" line="113"/>
+        <source>Initializing Core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Main.qml" line="115"/>
+        <source>Loading Podcasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerChaptersDialog</name>
     <message>
         <location filename="../qml/PlayerChaptersDialog.qml" line="37"/>

--- a/translations/harbour-org.gpodder.sailfish-sv.ts
+++ b/translations/harbour-org.gpodder.sailfish-sv.ts
@@ -256,6 +256,19 @@
     </message>
 </context>
 <context>
+    <name>Main</name>
+    <message>
+        <location filename="../qml/Main.qml" line="113"/>
+        <source>Initializing Core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Main.qml" line="115"/>
+        <source>Loading Podcasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerChaptersDialog</name>
     <message>
         <location filename="../qml/PlayerChaptersDialog.qml" line="37"/>

--- a/translations/harbour-org.gpodder.sailfish-zh_CN.ts
+++ b/translations/harbour-org.gpodder.sailfish-zh_CN.ts
@@ -256,6 +256,19 @@
     </message>
 </context>
 <context>
+    <name>Main</name>
+    <message>
+        <location filename="../qml/Main.qml" line="113"/>
+        <source>Initializing Core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Main.qml" line="115"/>
+        <source>Loading Podcasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerChaptersDialog</name>
     <message>
         <location filename="../qml/PlayerChaptersDialog.qml" line="37"/>

--- a/translations/harbour-org.gpodder.sailfish.ts
+++ b/translations/harbour-org.gpodder.sailfish.ts
@@ -256,6 +256,19 @@
     </message>
 </context>
 <context>
+    <name>Main</name>
+    <message>
+        <location filename="../qml/Main.qml" line="113"/>
+        <source>Initializing Core</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/Main.qml" line="115"/>
+        <source>Loading Podcasts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerChaptersDialog</name>
     <message>
         <location filename="../qml/PlayerChaptersDialog.qml" line="37"/>


### PR DESCRIPTION
This causes the loading indicator to persist until podcast loading is finished and adds some textual feedback to the user of what is happening.

Added in anticipation of folder migration processes which may be slow.